### PR TITLE
XaaS S3 - Bugfix

### DIFF
--- a/powershell/include/REST/XaaS/S3/ScalityWebConsoleAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/S3/ScalityWebConsoleAPI.inc.ps1
@@ -16,7 +16,7 @@
 #>
 Add-Type -AssemblyName System.Web
 
-class ScalityWebConsoleAPI: RESTAPI
+class ScalityWebConsoleAPI: RESTAPICurl
 {
 
     hidden [string]$server
@@ -44,8 +44,15 @@ class ScalityWebConsoleAPI: RESTAPI
 
         $uri = "https://{0}/_/console/authenticate" -f $this.server
 
+        $result = $this.callAPI($uri, "Post",  $body)
+        
+        if($result.success -eq $false)
+        {
+            Throw $result.error
+        }
+
         # Ajout du token pour les requêtes futures 
-        $this.headers.Add('x-access-token', ($this.callAPI($uri, "Post",  $body)).token)
+        $this.headers.Add('x-access-token', $result.token)
     }
 
 
@@ -55,11 +62,15 @@ class ScalityWebConsoleAPI: RESTAPI
 
         IN  : $requestResult    -> Résultat d'une requête.
     #>
-    hidden [void]handleError([string]$requestResult)
+    hidden [void]handleError([PSObject]$requestResult)
     {
         if($null -ne $requestResult.error)
         {
             Throw $requestResult.error
+        }
+        elseif($requestResult.success -eq $false)
+        {
+            Throw $requestResult.message
         }
     }
 

--- a/powershell/xaas-s3-endpoint.ps1
+++ b/powershell/xaas-s3-endpoint.ps1
@@ -433,6 +433,7 @@ try
             # Récupération de la liste des buckets et parcours
             $scality.getBucketList() | ForEach-Object {
 
+                $logHistory.addLine( ("Processing bucket {0}" -f $_.bucketName) )
                 # Récupération des infos d'utilisation
                 $usageInfos = $scality.getBucketUsageInfos($_.BucketName)
                 # Ajout du nom du bucket
@@ -445,8 +446,12 @@ try
 
     $logHistory.addLine("Script execution done!")
 
+
     # Affichage du résultat
     displayJSONOutput -output $output
+
+    # Ajout du résultat dans les logs 
+    $logHistory.addLine(($output | ConvertTo-Json -Depth 100))
 
 }
 catch


### PR DESCRIPTION
- Utilisation de Curl au lieu de PowerShell (`Invoke-RESTMethod`) pour faire les appels à la GUI web de Scality
- Ajout de gestion d'erreurs 
   - lors de l'authentification
   - lors du contrôle s'il y a eu une erreur suite à une requête REST
- Plus d'informations ajoutées dans les fichiers logs, y compris le résultat renvoyé à la fin de l'exécution du script

**NOTE**
2020-04-17 - Lars va ouvrir un incident chez Scality pour des problème d'authentification et gestion de sessions utilisateurs une fois connectés.