### PR TITLE
XaaS Backup - Does VM has snapshot ?

### DIFF
--- a/powershell/clean-iso-folders.ps1
+++ b/powershell/clean-iso-folders.ps1
@@ -256,6 +256,16 @@ try
 }
 catch # Dans le cas d'une erreur dans le script
 {
+	# Si on avait ouvert une connexion à vCenter, on la referme 
+	if($null -ne $vcenter)
+	{
+		Disconnect-VIServer -Server $vCenter -Confirm:$false 
+	}
+	if($null -ne $vra)
+    {
+        $vra.disconnect()
+	}
+
 	# Récupération des infos
 	$errorMessage = $_.Exception.Message
 	$errorTrace = $_.ScriptStackTrace

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -1342,6 +1342,26 @@ class vRAAPI: RESTAPICurl
 
 	}
 
+	<#
+		-------------------------------------------------------------------------------------
+		BUT : Renvoie un item donné pour son type et son nom
+			  
+		IN  : $itemType			-> Type d'item que l'on désire ('Virtual Machine' par exemple)
+		IN  : $itemName			-> Nom de l'item que l'on chercher
+
+		RET : Objet avec l'item
+			$null si pas trouvé
+	#>
+	[PSObject] getItem([string]$itemType, [string]$itemName)
+	{
+		$res = $this.getBGItemListQuery(("`$filter=resourceType/name eq '{0}' and name eq '{1}'" -f $itemType, $itemName))
+
+		if($res.length -eq 0)
+		{
+			return $null
+		}
+		return $res[0]
+	}
 
 	<#
 		-------------------------------------------------------------------------------------

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -882,11 +882,7 @@ class vRAAPI: RESTAPICurl
 		IN  : $queryParams	-> (Optionnel -> "") Chaine de caractères à ajouter à la fin
 										de l'URI afin d'effectuer des opérations supplémentaires.
 										Pas besoin de mettre le ? au début des $queryParams
-<<<<<<< HEAD
 		IN  : $allowCache	-> $true|$false pour dire si on peut utiliser le cache
-=======
-		IN  : $allowCache	-> $true|$false pour dire si on peut utiliser le cache	
->>>>>>> 5fed200c226339f72547090a70ba631237f4c8e2
 
 		RET : Liste des Reservations
 	#>

--- a/powershell/include/REST/vSphereAPI.inc.ps1
+++ b/powershell/include/REST/vSphereAPI.inc.ps1
@@ -335,7 +335,9 @@ class vSphereAPI: RESTAPICurl
 
 	<#
 		-------------------------------------------------------------------------------------
-        BUT : Renvoie la liste des tags d'une catégorie donnée
+		BUT : Renvoie la liste des tags d'une catégorie donnée
+		
+		IN  : $categoryName	-> Nom de la catégorie pour laquelle on veut les tags
 	#>
 	[Array] getTagList([string]$categoryName)
 	{
@@ -343,10 +345,5 @@ class vSphereAPI: RESTAPICurl
 
 		return $this.callAPI($uri, "Get", $null).value
 	}
-
-	
-	
-
-	
 
 }

--- a/powershell/vsphere-update-vm-notes.ps1
+++ b/powershell/vsphere-update-vm-notes.ps1
@@ -170,9 +170,12 @@ try
 
     $logHistory.addLineAndDisplay($counters.getDisplay("Counters summary"))
 
+    Disconnect-VIServer -Server $connectedvCenter -Confirm:$false 
 }
 catch
 {
+    Disconnect-VIServer -Server $connectedvCenter -Confirm:$false 
+    
 	# Récupération des infos
 	$errorMessage = $_.Exception.Message
 	$errorTrace = $_.ScriptStackTrace

--- a/powershell/xaas-backup-endpoint.ps1
+++ b/powershell/xaas-backup-endpoint.ps1
@@ -224,9 +224,12 @@ try
             }
             else
             {
+
                 $output.results += @{
                                         restoreJobId = $restoreJobId
                                         status = $jobDetails.attributes.state.ToLower()
+                                        # Cette valeur sera à $null si le job de restore est toujours en cours
+                                        code = $jobDetails.attributes.status
                                     }
             }
         }


### PR DESCRIPTION
- Ajout d'une fonctionnalité permettant de savoir si une VM a un snapshot en cours
- Mise à jour de commentaires de fonction
- Pour 2 scripts lancés via tâche planifiée, ajout de la déconnexion aux serveurs dans le cas où une erreur se produirait
- Résolution d'un conflit de merge bizarre... heureusement c'était dans un commentaire !
- Ajout d'une information quand on demande si un restore est en cours pour une VM. On renvoie aussi maintenant le code d'erreur (champ `status` de NetBackup). Voir documentation: https://confluence.epfl.ch:8443/display/SIAC/%5BXaaS%5D+xaas-backup-endpoints.ps1