### PR TITLE
vraUsers table for Tableau application

### DIFF
--- a/powershell/include/NameGenerator.inc.ps1
+++ b/powershell/include/NameGenerator.inc.ps1
@@ -1321,6 +1321,7 @@ class NameGenerator
         RET : Pour tenant EPFL, tableau avec :
                 - Nom de la faculté
                 - Nom de l'unité
+                - No du centre financier
             
               Pour tenant ITServices, tableau avec :
                 - Nom long du service

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -742,6 +742,21 @@ try
 					Remove-ADGroup $_.name -Confirm:$false
 				}
 
+				$logHistory.addLineAndDisplay(("--> Removing rights for '{0}' role in vraUsers table for AD groupe {1}" -f [TableauRoles]::User.ToString(), $_.name))
+
+				# Extraction des informations
+				$facultyName, $unitName, $financeCenter = $nameGenerator.extractInfosFromADGroupDesc($_.Description)
+
+				# Initialisation des détails pour le générateur de noms
+				$nameGenerator.initDetails(@{facultyName = $facultyName
+											facultyID = ''
+											unitName = $unitName
+											unitID = ''
+											financeCenter = ''})
+
+				# Suppression des accès pour le business group correspondant au groupe AD courant.
+				updateVRAUsersForBG -mysql $mysql -userList @() -role User -bgName $nameGenerator.getBGName()
+
 				$counters.inc('ADGroupsRemoved')
 			}
 		}# FIN BOUCLE de parcours des groupes AD qui sont dans l'OU de l'environnement donné

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -413,7 +413,7 @@ try
 		$ldap = [EPFLLDAP]::new()
 
 		# Recherche de toutes les facultés
-		$facultyList = $ldap.getLDAPFacultyList() # | Where-Object { $_['name'] -eq "ASSOCIATIONS" } # Décommenter et modifier pour limiter à une faculté donnée
+		$facultyList = $ldap.getLDAPFacultyList() #  | Where-Object { $_['name'] -eq "ASSOCIATIONS" } # Décommenter et modifier pour limiter à une faculté donnée
 
 		$exitFacLoop = $false
 
@@ -742,6 +742,8 @@ try
 					Remove-ADGroup $_.name -Confirm:$false
 				}
 
+				$counters.inc('ADGroupsRemoved')
+
 				$logHistory.addLineAndDisplay(("--> Removing rights for '{0}' role in vraUsers table for AD groupe {1}" -f [TableauRoles]::User.ToString(), $_.name))
 
 				# Extraction des informations
@@ -756,8 +758,6 @@ try
 
 				# Suppression des accès pour le business group correspondant au groupe AD courant.
 				updateVRAUsersForBG -mysql $mysql -userList @() -role User -bgName $nameGenerator.getBGName()
-
-				$counters.inc('ADGroupsRemoved')
 			}
 		}# FIN BOUCLE de parcours des groupes AD qui sont dans l'OU de l'environnement donné
 	}


### PR DESCRIPTION
- Ajout d'une table `vraUsers` dans la base de données pour lister les utilisateurs qui ont le droit d'accéder à Tableau avec différents Rôles.
La table a les colonnes suivantes :
   - username
   - role
   - crit1
   - crit2
   - crit3
- Modification des fichiers de config qui stockent les informations de configuration à la DB "vRA" pour stocker les mettre à un endroit plus logique
- Amélioration de la partie MySQL pour ne plus avoir de message de "Warning" affiché parce que le mot de passe est passé en clair dans la ligne de commande.
- Amélioration de `ConfigReader` pour avoir un niveau d'arborescence de plus pour stocker des données.
- Mise à jour d'un commentaire dans `NameGenerator`

# Information
@LuluTchab  s'est un peu foiré et une partie des modifications mentionnées ci-dessus sont en fait dans la PR #69 🤦 

# Après merge
Mettre à jour les fichiers JSON sur les infra pour les accès à la DB