### PR TITLE
MySQL module instead of "mysql.exe" command line usage

### DIFF
--- a/powershell/include/Billing.inc.ps1
+++ b/powershell/include/Billing.inc.ps1
@@ -306,7 +306,7 @@ class Billing
         {
             $request = "UPDATE BillingItem SET itemBillReference='{0}' WHERE parentEntityId='{1}' AND itemType='{2}' AND itemBillReference IS NULL " -f $billReference, $entityId, $itemType
 
-            $this.mysql.execute($request)
+            $nbUpdated = $this.mysql.execute($request)
         }   
     }
 
@@ -320,7 +320,7 @@ class Billing
     [void] cancelBill([string]$billReference)
     {
         $request = "UPDATE BillingItem SET itemBillReference=NULL WHERE itemBillReference='{0}'" -f $billReference
-        $this.mysql.execute($request)
+        $nbUpdated = $this.mysql.execute($request)
     }
 
 

--- a/powershell/include/MySQL.inc.ps1
+++ b/powershell/include/MySQL.inc.ps1
@@ -1,5 +1,9 @@
 <#
-   BUT : Classe permettant de faire des requêtes dans une DB MySQL. 
+   BUT : Classe permettant de faire des requêtes dans une DB MySQL. Beaucoup de choses déjà existantes
+         trouvées sur le NET pour faire ceci, y compris le connecteur .NET fournis par MySQL
+         (https://dev.mysql.com/downloads/connector/net/8.0.html) ne fonctionnent pas si le serveur ne fait pas de SSL.
+         Le seul qui fonctionne, c'est le module SimplySQL !
+
 
    AUTEUR : Lucien Chaboudez
    DATE   : Mai 2018

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -263,7 +263,7 @@ function updateVRAUsersForBG([MySQL]$mysql, [Array]$userList, [TableauRoles]$rol
 	$request = "DELETE FROM vraUsers WHERE role='{0}' AND {1}" -f $role, ($criteriaConditions -join " AND ")
 	#$mysql.execute($request)
 
-	Invoke-SQLQuery -Query $request
+	$nbDeleted = Invoke-SQLUpdate -Query $request
 
 	$baseRequest = "INSERT INTO vraUsers VALUES"
 	$rows = @()
@@ -279,7 +279,7 @@ function updateVRAUsersForBG([MySQL]$mysql, [Array]$userList, [TableauRoles]$rol
 			# On créé la requête et on l'exécute
 			$request = "{0}{1}" -f $baseRequest, ($rows -join ",")
 			#$mysql.execute($request)
-			Invoke-SQLQuery -Query $request
+			$nInserted = Invoke-SQLUpdate -Query $request
 			$rows = @()
 		}
 		
@@ -290,7 +290,7 @@ function updateVRAUsersForBG([MySQL]$mysql, [Array]$userList, [TableauRoles]$rol
 	{
 		$request = "{0}{1}" -f $baseRequest, ($rows -join ",")
 		#$mysql.execute($request)
-		Invoke-SQLQuery -Query $request
+		$nInserted = Invoke-SQLUpdate -Query $request
 	}
 
 	

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -354,7 +354,7 @@ try
 	# 						$configVra.getConfigValue($targetEnv, "db", "port"))
 
 	Import-Module ActiveDirectory
-	Import-Module SimplyMySQL
+	Import-Module SimplySQL
 
 	open-mysqlconnection -server $configVra.getConfigValue($targetEnv, "db", "host") `
 							 -database $configVra.getConfigValue($targetEnv, "db", "dbName") `

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -261,7 +261,9 @@ function updateVRAUsersForBG([MySQL]$mysql, [Array]$userList, [TableauRoles]$rol
 
 	# On commence par supprimer tous les utilisateurs du role donné pour le BG
 	$request = "DELETE FROM vraUsers WHERE role='{0}' AND {1}" -f $role, ($criteriaConditions -join " AND ")
-	$mysql.execute($request)
+	#$mysql.execute($request)
+
+	Invoke-SQLQuery -Query $request
 
 	$baseRequest = "INSERT INTO vraUsers VALUES"
 	$rows = @()
@@ -276,7 +278,8 @@ function updateVRAUsersForBG([MySQL]$mysql, [Array]$userList, [TableauRoles]$rol
 		{
 			# On créé la requête et on l'exécute
 			$request = "{0}{1}" -f $baseRequest, ($rows -join ",")
-			$mysql.execute($request)
+			#$mysql.execute($request)
+			Invoke-SQLQuery -Query $request
 			$rows = @()
 		}
 		
@@ -286,7 +289,8 @@ function updateVRAUsersForBG([MySQL]$mysql, [Array]$userList, [TableauRoles]$rol
 	if($rows.Count -gt 0)
 	{
 		$request = "{0}{1}" -f $baseRequest, ($rows -join ",")
-		$mysql.execute($request)
+		#$mysql.execute($request)
+		Invoke-SQLQuery -Query $request
 	}
 
 	
@@ -342,14 +346,23 @@ try
 	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MAIL_TEMPLATE_FOLDER, $targetEnv, $targetTenant)
 	
 	# Pour accéder à la base de données
-	$mysql = [MySQL]::new($configVra.getConfigValue($targetEnv, "db", "host"), `
-							$configVra.getConfigValue($targetEnv, "db", "dbName"), `
-							$configVra.getConfigValue($targetEnv, "db", "user"), `
-							$configVra.getConfigValue($targetEnv, "db", "password"), `
-							$global:BINARY_FOLDER, `
-							$configVra.getConfigValue($targetEnv, "db", "port"))
+	# $mysql = [MySQL]::new($configVra.getConfigValue($targetEnv, "db", "host"), `
+	# 						$configVra.getConfigValue($targetEnv, "db", "dbName"), `
+	# 						$configVra.getConfigValue($targetEnv, "db", "user"), `
+	# 						$configVra.getConfigValue($targetEnv, "db", "password"), `
+	# 						$global:BINARY_FOLDER, `
+	# 						$configVra.getConfigValue($targetEnv, "db", "port"))
 
 	Import-Module ActiveDirectory
+	Import-Module SimplyMySQL
+
+	open-mysqlconnection -server $configVra.getConfigValue($targetEnv, "db", "host") `
+							 -database $configVra.getConfigValue($targetEnv, "db", "dbName") `
+							 -port $configVra.getConfigValue($targetEnv, "db", "port") `
+							-username $configVra.getConfigValue($targetEnv, "db", "user") `
+							-password $configVra.getConfigValue($targetEnv, "db", "password")
+
+	$mysql = $null
 
 	if($SIMULATION_MODE)
 	{
@@ -934,6 +947,8 @@ try
 
 	$logHistory.addLineAndDisplay($counters.getDisplay("Counters summary"))
 
+	# Fermeture de la connexion MySQL
+	Close-SQLConnection
 
 }
 catch # Dans le cas d'une erreur dans le script

--- a/powershell/xaas-billing.ps1
+++ b/powershell/xaas-billing.ps1
@@ -255,13 +255,11 @@ try
 
     }
     
-
     # Pour accéder à la base de données
     $mysql = [MySQL]::new($configVra.getConfigValue($targetEnv, "db", "host"), `
                           $configVra.getConfigValue($targetEnv, "db", "dbName"), `
                           $configVra.getConfigValue($targetEnv, "db", "user"), `
                           $configVra.getConfigValue($targetEnv, "db", "password"), `
-                          $global:BINARY_FOLDER, `
                           $configVra.getConfigValue($targetEnv, "db", "port"))
 
     $ldap = [EPFLLDAP]::new()
@@ -652,6 +650,8 @@ try
 
     # Résumé des actions entreprises
     $logHistory.addLineAndDisplay($counters.getDisplay("Counters summary"))
+
+    $mysql.disconnect()
 
 }
 catch


### PR DESCRIPTION
Il a été constaté que depuis les machines dans le subnet 10.x.x.x il pouvait y avoir des requêtes qui passaient tout droit et qui n'étaient pas traitées par la DB malgré le fait que le "exitCode" de "mysql.exe" soit toujours de 0 !

Petite investigation au travers de INC0357203 et pas trouvé de solution...

Donc, utilisation du module `SimplySQL` (https://www.powershellgallery.com/packages/SimplySql/1.6.2) car ça semble être le seul qui fonctionne bien sans le SSL (tous les autres modules testés par le passés avaient besoin du SSL).

# Durant mise en production
- Installer le module pour MySQL en suivant la doc au bas de la page https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI
