### PR TITLE
S3 bucket size fix

### DIFF
--- a/powershell/include/REST/RESTAPICurl.inc.ps1
+++ b/powershell/include/REST/RESTAPICurl.inc.ps1
@@ -146,10 +146,12 @@ class RESTAPICurl: RESTAPI
 				
 				$result = $output | ConvertFrom-Json
 	
+				# Si pas trouvé
 				if($result.httpStatus -eq "NOT_FOUND")
 				{
+					# On peut simplement sortir de la boucle
 					$result = $null
-					
+					break	
 				}
 				
 				# Si rien reçu ou code d'erreur

--- a/powershell/include/REST/RESTAPICurl.inc.ps1
+++ b/powershell/include/REST/RESTAPICurl.inc.ps1
@@ -152,8 +152,8 @@ class RESTAPICurl: RESTAPI
 					
 				}
 				
-				# Si code d'erreur
-				if($null -ne $result.error_code)
+				# Si rien reçu ou code d'erreur
+				if(($null -eq $result) -or ($null -ne $result.error_code))
 				{
 					# Si on a fait le max de tentative, on peut lever une erreur
 					if($currentAttemptNo -eq $nbCurlAttempts)


### PR DESCRIPTION
Correction d'un bug dans l'utilisation de Curl en ligne de commande. Il semblerait que dans quelques cas particuliers, le retour envoyé par Curl soit une chaîne vide. Auquel cas, lorsque l'on transforme ceci en JSON, cela donne `$null`. Et dans ce cas-là on devrait tenter un Retry au lieu de retourner `$null`.

Etant donné que l'erreur n'apparaît pas à tous les coups, il n'est pas possible de tester cette correction avant la mise en production 😨 