### PR TITLE
Finance center level 4 for level 3 units (centers)

### DIFF
--- a/powershell/data/ge-unit-mapping.json
+++ b/powershell/data/ge-unit-mapping.json
@@ -1,0 +1,10 @@
+[
+    {
+        "level3Center": "SI-VP",
+        "level4GeUnit": "VPSI"
+    },
+    {
+        "level3Center": "RH-RH",
+        "level4GeUnit": "RH-G"
+    }
+]

--- a/powershell/data/ge-unit-mapping.json
+++ b/powershell/data/ge-unit-mapping.json
@@ -6,5 +6,77 @@
     {
         "level3Center": "RH-RH",
         "level4GeUnit": "RH-G"
+    },
+    {
+        "level3Center": "CDM-SG",
+        "level4GeUnit": "CDM-GE"
+    },
+    {
+        "level3Center": "E-FC",
+        "level4GeUnit": "EXTS-GE"
+    },
+    {
+        "level3Center": "ENAC-SG",
+        "level4GeUnit": "ENAC-GE"
+    },
+    {
+        "level3Center": "ENT-E-GES",
+        "level4GeUnit": "ENT-E-GE"
+    },
+    {
+        "level3Center": "ENT-P-GES",
+        "level4GeUnit": "ENT-P-GE"
+    },
+    {
+        "level3Center": "ENT-R-GES",
+        "level4GeUnit": "ENT-R-GE"
+    },
+    {
+        "level3Center": "EPFL-ECAL-L",
+        "level4GeUnit": "EPFL-ECAL-GE"
+    },
+    {
+        "level3Center": "E-VP",
+        "level4GeUnit": "VPE"
+    },
+    {
+        "level3Center": "IC-SG",
+        "level4GeUnit": "IC-GE"
+    },
+    {
+        "level3Center": "P-APR",
+        "level4GeUnit": "APR"
+    },
+    {
+        "level3Center": "P-MEDIACOM",
+        "level4GeUnit": "MEDIACOM"
+    },
+    {
+        "level3Center": "PRN-MARVEL",
+        "level4GeUnit": "PRNMARVEL-GE"
+    },
+    {
+        "level3Center": "PRN-ROBOTICS",
+        "level4GeUnit": "PRN-ROBOT-GE"
+    },
+    {
+        "level3Center": "PTECH",
+        "level4GeUnit": "PTEC-GE"
+    },
+    {
+        "level3Center": "RHO-VP",
+        "level4GeUnit": "VPRHO"
+    },
+    {
+        "level3Center": "R-VP",
+        "level4GeUnit": "VPR"
+    },
+    {
+        "level3Center": "STI-SG",
+        "level4GeUnit": "STI-GE"
+    },
+    {
+        "level3Center": "SV-SG",
+        "level4GeUnit": "SV-GE"
     }
 ]

--- a/powershell/include/EPFLLDAP.inc.ps1
+++ b/powershell/include/EPFLLDAP.inc.ps1
@@ -211,10 +211,15 @@ class EPFLLDAP
 			# Parcours des résultats pour reformater,
 			ForEach($curUnit in $allUnits)
 			{
+				# Extraction de la fin du path et compte du nombre de niveau
+				# Ex: LDAP://ldap.epfl.ch:636/ou=si-vp,ou=si,o=epfl,c=ch  vers OU=SI-VP,OU=SI,O=EPFL,C=CH
+				$level = ([Regex]::match($curunit.path, '.*\/(.*)').Groups[1].value.toUpper() -Split ",").Count -1
+				
 				# Création de l'objet
 				$unitList += @{name = $curUnit.Properties['ou'][0]
 								uniqueidentifier = $curUnit.Properties['uniqueidentifier'][0]
-								accountingnumber = $curUnit.Properties['accountingnumber'][0] }
+								accountingnumber = $curUnit.Properties['accountingnumber'][0]
+								level = $level}
 			} # FIN BOUCLE de parcours des résultats
 		}
 		return $unitList

--- a/powershell/resources/mail-templates/level-4-ge-unit-not-found.html
+++ b/powershell/resources/mail-templates/level-4-ge-unit-not-found.html
@@ -1,0 +1,7 @@
+Il n'a pas été possible de trouver les unités de niveau 4 (Gestion) associées aux unités de niveau 3 (centre) ci-dessous.<br> 
+De ce fait, ce n'est pour le moment pas le bon numéro de centre financier qui a été mis pour l'unité.<br><br>
+Veuillez suivre la documentation <a href="https://sico.epfl.ch:8443/pages/viewpage.action?pageId=130975579">ici</a> pour corriger le problème.
+<br>
+<ul>
+    <li>{{unitList}}</li>
+</ul>

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -435,7 +435,7 @@ try
 		ForEach($faculty in $facultyList)
 		{
 			$counters.inc('epfl.facProcessed')
-			$logHistory.addLineAndDisplay(("[{0}/{1}] Faculty {2}..." -f $counters.get('epfl.facProcessed'), $facultyList.Count, $faculty['name']))
+			$logHistory.addLineAndDisplay(("[{0}/{1}] Faculty {2}..." -f $counters.get('epfl.facProcessed'), $facultyList.Count, $faculty.name))
 			
 			# ----------------------------------------------------------------------------------
 			# --------------------------------- FACULTE
@@ -445,8 +445,8 @@ try
 			# NOTE: On ne connait pas encore toutes les informations donc on initialise 
 			# avec juste celles qui sont nécessaires pour la suite. Le reste, on met une
 			# chaîne vide.
-			$nameGenerator.initDetails(@{facultyName = $faculty['name']
-										facultyID = $faculty['uniqueidentifier']
+			$nameGenerator.initDetails(@{facultyName = $faculty.name
+										facultyID = $faculty.uniqueidentifier
 										unitName = ''
 										unitID = ''
 										financeCenter = ''})
@@ -534,13 +534,13 @@ try
 			# ----------------------------------------------------------------------------------
 
 			# Recherche des unités pour la facultés
-			$unitList = $ldap.getFacultyUnitList($faculty['name'], $EPFL_FAC_UNIT_NB_LEVEL) # | Where-Object { $_['name'] -eq 'OSUL'} # Décommenter et modifier pour limiter à une unité donnée
+			$unitList = $ldap.getFacultyUnitList($faculty.name, $EPFL_FAC_UNIT_NB_LEVEL) # | Where-Object { $_['name'] -eq 'OSUL'} # Décommenter et modifier pour limiter à une unité donnée
 
 			$unitNo = 1
 			# Parcours des unités de la faculté
 			ForEach($unit in $unitList)
 			{
-				$logHistory.addLineAndDisplay(("-> [{0}/{1}] Unit {2} => {3}..." -f $unitNo, $unitList.Count, $faculty['name'], $unit['name']))
+				$logHistory.addLineAndDisplay(("-> [{0}/{1}] Unit {2} => {3}..." -f $unitNo, $unitList.Count, $faculty.name, $unit.name))
 
 				# Recherche des membres de l'unité
 				$ldapMemberList = $ldap.getUnitMembers($unit['uniqueidentifier'])
@@ -549,11 +549,11 @@ try
 				$ldapMemberList = removeInexistingADAccounts -accounts $ldapMemberList
 
 				# Initialisation des détails pour le générateur de noms
-				$nameGenerator.initDetails(@{facultyName = $faculty['name']
-											facultyID = $faculty['uniqueidentifier']
-											unitName = $unit['name']
-											unitID = $unit['uniqueidentifier']
-											financeCenter = $unit['accountingnumber']})
+				$nameGenerator.initDetails(@{facultyName = $faculty.name
+											facultyID = $faculty.uniqueidentifier
+											unitName = $unit.name
+											unitID = $unit.uniqueidentifier
+											financeCenter = $unit.accountingnumber})
 
 				# Création du nom du groupe AD et de la description
 				$adGroupName = $nameGenerator.getRoleADGroupName("CSP_CONSUMER", $false)
@@ -604,7 +604,7 @@ try
 					}
 					else # Pas de membres donc on ne créé pas le groupe
 					{
-						$logHistory.addLineAndDisplay(("--> No members in unit '{0}', skipping group creation " -f $unit['name']))
+						$logHistory.addLineAndDisplay(("--> No members in unit '{0}', skipping group creation " -f $unit.name))
 						$counters.inc('epfl.LDAPUnitsEmpty')
 						$adGroupExists = $false
 					}
@@ -711,8 +711,8 @@ try
 			if($facApprovalMembers.Count -gt 0)
 			{
 				$logHistory.addLineAndDisplay(("--> Adding {0} members with '{1}' role to vraUsers table " -f $facApprovalMembers.Count, [TableauRoles]::AdminFac.ToString() ))
-				updateVRAUsersForBG -sqldb $sqldb -userList $facApprovalMembers -role AdminFac -bgName ("epfl_{0}" -f $faculty['name'].toLower())
-				updateVRAUsersForBG -sqldb $mysql -userList $facApprovalMembers -role AdminFac -bgName ("epfl_{0}" -f $faculty['name'].toLower())
+				updateVRAUsersForBG -sqldb $sqldb -userList $facApprovalMembers -role AdminFac -bgName ("epfl_{0}" -f $faculty.name.toLower())
+				updateVRAUsersForBG -sqldb $mysql -userList $facApprovalMembers -role AdminFac -bgName ("epfl_{0}" -f $faculty.name.toLower())
 			}
 
 

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -155,6 +155,18 @@ function handleNotifications([System.Collections.IDictionary] $notifications, [s
 					$templateName = "ad-groups-missing-for-groups-creation"
 				}
 
+				# ---------------------------------------
+				# Unité 'Gestion' pas trouvée au niveau 4 pour une unité de niveau 3
+				'level3GEUnitNotFound'
+				{
+					$valToReplace.unitList = ($uniqueNotifications -join "</li>`n<li>")
+					$valToReplace.docUrl = "https://sico.epfl.ch:8443/pages/viewpage.action?pageId=130975579"
+
+					$mailSubject = "Error - Level 4 'GE' unit can't be identified, please proceed manually"
+
+					$templateName = "level-4-ge-unit-not-found"
+				}
+
 				default
 				{
 					# Passage à l'itération suivante de la boucle
@@ -392,6 +404,7 @@ try
 	$counters.add('ADGroupsMembersRemoved', '# AD Group members removed')
 	$counters.add('ADMembersNotFound', '# AD members not found')
 	$counters.add('membersAddedTovRAUsers', '# Users added to vraUsers table (Tableau)')
+	$counters.add('level3GEUnitNotFound', '# level 3 GE unit not found')
 
 	<# Pour enregistrer des notifications à faire par email. Celles-ci peuvent être informatives ou des erreurs à remonter
 	aux administrateurs du service
@@ -402,6 +415,7 @@ try
 	(cette liste sera accédée en variable globale même si c'est pas propre XD)
 	#>
 	$notifications = @{}
+	$notifications.level3GEUnitNotFound = @()
 
 
 	# -------------------------------------------------------------------------------------------------------------------------------------
@@ -430,6 +444,10 @@ try
 		$facultyList = $ldap.getLDAPFacultyList() #  | Where-Object { $_['name'] -eq "ASSOCIATIONS" } # Décommenter et modifier pour limiter à une faculté donnée
 
 		$exitFacLoop = $false
+
+		# Chargement des informations sur le mapping des facultés
+		$geUnitMappingFile = ([IO.Path]::Combine($global:DATA_FOLDER, "ge-unit-mapping.json"))
+		$geUnitMappingList = (Get-Content -Path $geUnitMappingFile -raw) | ConvertFrom-Json
 
 		# Parcours des facultés trouvées
 		ForEach($faculty in $facultyList)
@@ -542,6 +560,51 @@ try
 			{
 				$logHistory.addLineAndDisplay(("-> [{0}/{1}] Unit {2} => {3}..." -f $unitNo, $unitList.Count, $faculty.name, $unit.name))
 
+
+				# Si c'est une unité de niveau 3 (centre), on doit chercher l'unité de niveau 4 qui fait office de "gestion"
+				if($unit.level -eq 3)
+				{
+					$logHistory.addLineAndDisplay("--> Level 3 unit (Center), looking for level 4 'GE' unit for finance center..." )
+
+					# Noms d'unité à rechercher. On cherche de plusieurs manières parce qu'ils ont été incapables de nommer ça d'une façon cohérente...
+					$geUnitNameList = @( ("{0}-GE" -f $unit.name)
+										 ("{0}-GE" -f [Regex]::match($unit.name, '[A-Za-z]+-(.*)').groups[1].value) )
+
+					# Ajout d'un potentiel mapping hard-codé dans le fichier JSON
+					$geUnitNameList += ($geUnitMappingList | Where-Object { $_.level3Center -eq $unit.name }).level4GeUnit
+
+					$financeCenter = $null
+
+					# Parcours des noms d'unité de "Gestion" pour voir si on trouve quelque chose
+					ForEach($geUnitName in $geUnitNameList)
+					{
+						$logHistory.addLineAndDisplay(("---> Looking for '{0}' unit..." -f $geUnitName))
+						$geUnit = $unitList | Where-Object { $_.name -eq $geUnitName }
+
+						if($null -ne $geUnit)
+						{
+							$logHistory.addLineAndDisplay("---> Unit found, getting finance center")
+							$financeCenter = $geUnit.accountingnumber
+							break
+						}
+					}
+
+					# Si on n'a rien trouvé... 
+					if($null -eq $financeCenter)
+					{
+						$logHistory.addLineAndDisplay("--> 'GE' unit not found... using 'normal' finance center")
+						$financeCenter = $unit.accountingnumber
+						$counters.inc('level3GEUnitNotFound')
+						# Ajout du nom de l'unité niveau 3 pour notifier par mail que pas trouvée
+						$notifications.level3GEUnitNotFound += $unit.name
+					}
+				}
+				else # Ce n'est pas une unité de niveau 3 (centre)
+				{
+					$financeCenter = $unit.accountingnumber
+				}
+
+
 				# Recherche des membres de l'unité
 				$ldapMemberList = $ldap.getUnitMembers($unit['uniqueidentifier'])
 
@@ -553,7 +616,7 @@ try
 											facultyID = $faculty.uniqueidentifier
 											unitName = $unit.name
 											unitID = $unit.uniqueidentifier
-											financeCenter = $unit.accountingnumber})
+											financeCenter = $financeCenter})
 
 				# Création du nom du groupe AD et de la description
 				$adGroupName = $nameGenerator.getRoleADGroupName("CSP_CONSUMER", $false)

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -398,12 +398,10 @@ function createOrUpdateBG
 		$counters.inc('BGExisting')
 		# ==========================================================================================
 
-		# Si le BG n'a pas la custom property donnée, on l'ajoute
-		# FIXME: Cette partie de code pourra être enlevée au bout d'un moment car elle est juste prévue pour mettre à jours
-		# les BG existants avec la nouvelle "Custom Property"
-		if($null -eq (getBGCustomPropValue -bg $bg -customPropName $global:VRA_CUSTOM_PROP_EPFL_BILLING_FINANCE_CENTER))
+		# Si le centre financier du BG a changé (ce qui peut arriver), on le met à jour
+		if((getBGCustomPropValue -bg $bg -customPropName $global:VRA_CUSTOM_PROP_EPFL_BILLING_FINANCE_CENTER) -ne $financeCenter)
 		{
-			# Ajout de la custom Property avec la valeur par défaut 
+			# Mise à jour
 			$bg = $vra.updateBG($bg, $bgName, $bgDesc, $machinePrefixId, @{"$global:VRA_CUSTOM_PROP_EPFL_BILLING_FINANCE_CENTER" = $financeCenter})
 		}
 
@@ -1353,7 +1351,6 @@ try
 
 
 	$logHistory.addLineAndDisplay(("Executed with parameters: Environment={0}, Tenant={1}" -f $targetEnv, $targetTenant))
-
 
 	
 	# Création d'une connexion au serveur vRA pour accéder à ses API REST


### PR DESCRIPTION
Etant donné que les centres financiers des unités de niveau 3 (appelées "centre") ne sont pas ajoutée dans Copernic, il faut récupérer l'unité de niveau 4 de type "Gestion" qui se trouve sous l'unité niveau 3 et mettre le centre financier de celle-ci à la place.

**Autres modifications**
- Utilisation de `.property`  au lieu de `['<property>']` pour accéder une valeur de hashtable.

# Après merge dans master
- Editer la page https://sico.epfl.ch:8443/pages/viewpage.action?pageId=130975579 pour mettre à jour (si besoin) le chemin jusqu'au fichier JSON de mapping