### PR TITLE
Standard file encoding when calling "Groups" API

### DIFF
--- a/powershell/include/REST/GroupsAPI.inc.ps1
+++ b/powershell/include/REST/GroupsAPI.inc.ps1
@@ -31,11 +31,14 @@ class GroupsAPI: RESTAPICurl
 	GroupsAPI([string] $server, [string] $appName, [string] $callerSciper, [string]$password) : base($server) # Ceci appelle le constructeur parent
 	{
         $this.headers.Add('Accept', 'application/json')
-        $this.headers.Add('Content-Type', 'application/json')
+        $this.headers.Add('Content-Type', 'application/x-www-form-urlencoded')
         
         $this.appName = $appName
         $this.callerSciper = $callerSciper
         $this.password = $password
+
+        # L'API sur https://groups.epfl.ch ne supporte pas l'UTF-8 donc on utilise l'encodage par défaut
+        $this.usePSDefaultEncoding()
     }
 
 


### PR DESCRIPTION
Semblerait que l'API de https://groups.epfl.ch ne gère pas les fichiers passés en UTF-8 (on est récemment passé à ceci)... donc ajout du nécessaire pour faire en sorte de pouvoir utiliser l'encodage par défaut de PowerShell pour écrire le fichier transmis à Curl.