### PR TITLE
XaaS NAS v2

### DIFF
--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -1155,7 +1155,7 @@ class NetAppAPI: RESTAPICurl
             if($doneIPs -contains $ip){ Continue }
 
             $replace = @{
-                clientMatch = $ip
+                clientMatch = $ip.Trim()
                 roRule = "any"
                 protocol = $protocol.toString()
             }
@@ -1196,7 +1196,7 @@ class NetAppAPI: RESTAPICurl
             if($doneIPs -contains $ip){ continue }
 
             $replace = @{
-                clientMatch = $ip
+                clientMatch = $ip.Trim()
                 rwRule = "any"
                 roRule = "any"
                 protocol = $protocol.toString()
@@ -1225,7 +1225,7 @@ class NetAppAPI: RESTAPICurl
             if($doneIPs -contains $ip){ continue }
 
             $replace = @{
-                clientMatch = $ip
+                clientMatch = $ip.Trim()
                 superUser = "any"
                 rwRule = "any"
                 roRule = "any"

--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -525,6 +525,34 @@ class NetAppAPI: RESTAPICurl
 
     <#
 		-------------------------------------------------------------------------------------
+        BUT : Retourne le protocol d'accès
+        
+        IN  : $vol   -> Objet représentant le volume
+
+        RET : "nfs3"|"cifs" Pour que ça puisse être réutilisé directement dans la fonction updateExportPolicyRules
+                $null si pas trouvé
+	#>
+    [string] getVolumeAccessProtocol([PSObject]$vol)
+    {
+        $uri = "/api/storage/volumes/{0}?fields=nas.security_style" -f $vol.uuid
+
+        $vol = $this.callAPI($uri, "GET", $null, "", $true)
+
+        if($null -eq $vol)
+        {
+            return $null
+        }
+
+        if($vol.nas.security_style -eq "unix")
+        {
+            return "nfs3"
+        }
+        return "cifs"
+    }
+
+
+    <#
+		-------------------------------------------------------------------------------------
         BUT : Retourne les informations d'un Volume en fonction de son nom
         
         IN  : $name   -> Nom du volume

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -655,27 +655,27 @@ try
 
                 $volSizeInfos = $netapp.getVolumeSizeInfos($vol)
 
-                $volSizeKB = $vol.space.size / 1024 
+                $volSizeB = $vol.space.size
                 # Suppression de l'espace réservé pour les snapshots
-                $userSizeKB = $volSizeKB * (1 - ($volSizeInfos.space.snapshot.reserve_percent/100))
-                $snapSizeKB = $volSizeKB * ($volSizeInfos.space.snapshot.reserve_percent/100)
+                $userSizeB = $volSizeB * (1 - ($volSizeInfos.space.snapshot.reserve_percent/100))
+                $snapSizeB = $volSizeB * ($volSizeInfos.space.snapshot.reserve_percent/100)
 
                 $output.results += @{
                     # Infos "globales"
                     volName = $vol.name
-                    totSizeKB = (truncateToNbDecimal -number ($volSizeKB) -nbDecimals 2)
+                    totSizeB = (truncateToNbDecimal -number ($volSizeB) -nbDecimals 2)
                     # Taille niveau "utilisateur"
                     user = @{
-                        sizeKB = (truncateToNbDecimal -number $userSizeKB -nbDecimals 2)
-                        usedKB = (truncateToNbDecimal -number ($vol.space.used / 1024) -nbDecimals 2)
+                        sizeB = (truncateToNbDecimal -number $userSizeB -nbDecimals 2)
+                        usedB = (truncateToNbDecimal -number $vol.space.used -nbDecimals 2)
                         usedFiles = $volSizeInfos.files.used
                         maxFiles = $volSizeInfos.files.maximum
                     }
                     # Taille niveau "snapshot"
                     snap = @{
                         reservePercent = $volSizeInfos.space.snapshot.reserve_percent
-                        reserveSizeKB = (truncateToNbDecimal -number $snapSizeKB -nbDecimals 2)
-                        usedKB = (truncateToNbDecimal -number ($volSizeInfos.space.snapshot.used / 1024) -nbDecimals 2)
+                        reserveSizeKB = (truncateToNbDecimal -number $snapSizeB -nbDecimals 2)
+                        usedB = (truncateToNbDecimal -number $volSizeInfos.space.snapshot.used -nbDecimals 2)
                     }
                 }
             }

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -651,23 +651,27 @@ try
 
                 $volSizeInfos = $netapp.getVolumeSizeInfos($vol)
 
-                $volSizeGB = $vol.space.size / 1024 / 1024 / 1024
+                $volSizeKB = $vol.space.size / 1024 
                 # Suppression de l'espace réservé pour les snapshots
-                $userSizeGB = $volSizeGB * (1 - ($volSizeInfos.space.snapshot.reserve_percent/100))
-                $snapSizeGB = $volSizeGB * ($volSizeInfos.space.snapshot.reserve_percent/100)
+                $userSizeKB = $volSizeKB * (1 - ($volSizeInfos.space.snapshot.reserve_percent/100))
+                $snapSizeKB = $volSizeKB * ($volSizeInfos.space.snapshot.reserve_percent/100)
 
                 $output.results += @{
+                    # Infos "globales"
                     volName = $vol.name
+                    totSizeKB = (truncateToNbDecimal -number ($volSizeKB) -nbDecimals 2)
+                    # Taille niveau "utilisateur"
                     user = @{
-                        sizeGB = (truncateToNbDecimal -number $userSizeGB -nbDecimals 2)
-                        usedGB = (truncateToNbDecimal -number ($vol.space.used / 1024 / 1024 / 1024) -nbDecimals 2)
+                        sizeKB = (truncateToNbDecimal -number $userSizeKB -nbDecimals 2)
+                        usedKB = (truncateToNbDecimal -number ($vol.space.used / 1024) -nbDecimals 2)
                         usedFiles = $volSizeInfos.files.used
                         maxFiles = $volSizeInfos.files.maximum
                     }
+                    # Taille niveau "snapshot"
                     snap = @{
                         reservePercent = $volSizeInfos.space.snapshot.reserve_percent
-                        reserveSizeGB = (truncateToNbDecimal -number $snapSizeGB -nbDecimals 2)
-                        usedGB = (truncateToNbDecimal -number ($volSizeInfos.space.snapshot.used / 1024 / 1024 / 1024) -nbDecimals 2)
+                        reserveSizeKB = (truncateToNbDecimal -number $snapSizeKB -nbDecimals 2)
+                        usedKB = (truncateToNbDecimal -number ($volSizeInfos.space.snapshot.used / 1024) -nbDecimals 2)
                     }
                 }
             }


### PR DESCRIPTION
Amélioration des fonctionnalités fournies pour le XaaS NAS
- Possibilité de dire si on veut des snapshots ou pas pour un volume collaboratif
- Remontée de la taille totale du volume (en plus du détails "user" et "snap") lorsque l'on appelle `getVolSize`
- Les tailles des volumes sont maintenant exprimées en Bytes au lieu de Bytes, pour avoir un peu plus de "granularité" pour la facturation
- Possibilité d'avoir la liste des IP pour un volume (`getIPList`)
- Possibilité de mettre à jour la liste des IP pour un volume (`updateIPList`) 
- Suppression des espaces éventuels dans la liste des IP
- Petites corrections dans les types retournés dans la classe `NetAppAPI`
