### PR TITLE
XaaS NAS - Change parameters for snapshot policy

### DIFF
--- a/powershell/clean-ghost-bg.ps1
+++ b/powershell/clean-ghost-bg.ps1
@@ -122,7 +122,7 @@ function deleteBGAndComponentsIfPossible([vRAAPI]$vra, [GroupsAPI]$groupsApp, [N
 			# Suppression de l'entitlement (on le désactive au préalable)
 			$logHistory.addLineAndDisplay(("--> Deleting Entitlement '{0}'..." -f $bgEnt.name))
 			# Désactivation
-			$dummy = $vra.updateEnt($bgEnt, $false)
+			$vra.updateEnt($bgEnt, $false) | Out-Null
 			$vra.deleteEnt($bgEnt.id)
 		}
 

--- a/powershell/clean-iso-folders.ps1
+++ b/powershell/clean-iso-folders.ps1
@@ -87,7 +87,7 @@ function Set-CDDriveAndAnswer
   {
     
       $cd = Get-CDDrive -VM $vm
-      $job = Start-Job -Name Check-CDQuestion -ScriptBlock $cdQuestion -ArgumentList $vm
+      Start-Job -Name Check-CDQuestion -ScriptBlock $cdQuestion -ArgumentList $vm | Out-Null
       Set-CDDrive -CD $cd -NoMedia -Confirm:$false -ErrorAction Stop
     
   }
@@ -171,7 +171,7 @@ try
 
 			# Pour éviter que le script parte en erreur si le certificat vCenter ne correspond pas au nom DNS primaire. On met le résultat dans une variable
 			# bidon sinon c'est affiché à l'écran.
-			$dummy = Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -Confirm:$false
+			Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -Confirm:$false | Out-Null
 
 			$credSecurePwd = $configVSphere.getConfigValue($targetEnv, "password") | ConvertTo-SecureString -AsPlainText -Force
 			$credObject = New-Object System.Management.Automation.PSCredential -ArgumentList $configVSphere.getConfigValue($targetEnv, "user"), $credSecurePwd	

--- a/powershell/concat-log-files.ps1
+++ b/powershell/concat-log-files.ps1
@@ -44,7 +44,7 @@ Get-ChildItem -Path $rootLogFolder -Recurse:$false -Directory | ForEach-Object {
         # Si le fichier dans lequel on veut regrouper n'existe pas,
         if(!(Test-Path -Path $mergeLogFile))
         {
-            $dummy = New-Item -ItemType File -Path $mergeLogFile
+            New-Item -ItemType File -Path $mergeLogFile | Out-Null
         }
 
         # Parcours des fichiers qui sont dans le dossier (ils sont parcourus par ordre alphabétique )
@@ -52,7 +52,7 @@ Get-ChildItem -Path $rootLogFolder -Recurse:$false -Directory | ForEach-Object {
             Write-Host ("--> Processing log file {0}..." -f $_.Name)
 
             # Ajout du contenu du fichier LOG courant dans le "global"
-            $dummy = Get-Content -Path $_.FullName | Add-Content -Path $mergeLogFile
+            Get-Content -Path $_.FullName | Add-Content -Path $mergeLogFile
             
             Write-Host ("--> Removing log file {0}..." -f $_.Name)
             # Suppression du fichier log courant

--- a/powershell/config/config-xaas-s3-sample.json
+++ b/powershell/config/config-xaas-s3-sample.json
@@ -21,6 +21,11 @@
             "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
             "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
             "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
+        },
+        "backupadmins": {
+            "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
+            "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
+            "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
         }
     },
     "test": {
@@ -45,6 +50,11 @@
             "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
             "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
             "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
+        },
+        "backupadmins": {
+            "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
+            "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
+            "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
         }
     },
     "prod": {
@@ -66,6 +76,11 @@
             "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
         },
         "research": {
+            "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
+            "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
+            "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
+        },
+        "backupadmins": {
             "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
             "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
             "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"

--- a/powershell/config/config-xaas-s3-sample.json
+++ b/powershell/config/config-xaas-s3-sample.json
@@ -21,11 +21,6 @@
             "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
             "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
             "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
-        },
-        "backupadmins": {
-            "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
-            "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
-            "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
         }
     },
     "test": {
@@ -50,11 +45,6 @@
             "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
             "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
             "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
-        },
-        "backupadmins": {
-            "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
-            "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
-            "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
         }
     },
     "prod": {
@@ -76,11 +66,6 @@
             "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
         },
         "research": {
-            "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
-            "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
-            "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"
-        },
-        "backupadmins": {
             "credentialProfile": "Nom du profil AWS défini en local avec SecretKey et AccessKey. Voir https://confluence.epfl.ch:8443/display/SIAC/PowerShell+CLI#PowerShellCLI-AWS(Amazon)",
             "webConsoleUser": "Ne remplir que si 'isScality'==true, sinon, laisser vide",
             "webConsolePassword": "Ne remplir que si 'isScality'==true, sinon, laisser vide"

--- a/powershell/include/Billing.inc.ps1
+++ b/powershell/include/Billing.inc.ps1
@@ -107,7 +107,7 @@ class Billing
         # L'entité n'existe pas, donc on l'ajoute 
         $request = "INSERT INTO BillingEntity VALUES (NULL, '{0}', '{1}', '{2}')" -f $type.toString(), $element, $financeCenter
 
-        $res =  $this.db.execute($request)
+        $this.db.execute($request) | Out-Null
 
         return [int] ($this.getEntity($type, $element)).entityId
     }
@@ -175,7 +175,7 @@ class Billing
         $request = "INSERT INTO BillingItem VALUES (NULL, '{0}', '{1}', '{2}', '{3}', '{4}', '{5}', '{6}', '{7}', '{8}', NULL)" -f `
                             $parentEntityId, $type, $name, $desc, $month, $year, $quantity, $unit, $priceLevel
 
-        $res = $this.db.execute($request)
+        $this.db.execute($request) | Out-Null
 
         return [int]($this.getItem($name, $month, $year)).itemId
     }
@@ -311,7 +311,7 @@ class Billing
         {
             $request = "UPDATE BillingItem SET itemBillReference='{0}' WHERE parentEntityId='{1}' AND itemType='{2}' AND itemBillReference IS NULL " -f $billReference, $entityId, $itemType
 
-            $nbUpdated = $this.db.execute($request)
+            $this.db.execute($request) | Out-Null
         }   
     }
 
@@ -325,7 +325,7 @@ class Billing
     [void] cancelBill([string]$billReference)
     {
         $request = "UPDATE BillingItem SET itemBillReference=NULL WHERE itemBillReference='{0}'" -f $billReference
-        $nbUpdated = $this.db.execute($request)
+        $this.db.execute($request) | Out-Null
     }
 
 

--- a/powershell/include/BillingS3Bucket.inc.ps1
+++ b/powershell/include/BillingS3Bucket.inc.ps1
@@ -175,7 +175,7 @@ class BillingS3Bucket: Billing
             # Description de l'élément (qui sera mise ensuite dans le PDF de la facture)
             $itemDesc = "{0}`n({1})`nOwner: {2}" -f $bucket.bucketName, $bucket.friendlyName, $vraBucket.owners[0].value
 
-            $itemId = $this.addItem($entityId, $this.serviceBillingInfos.billedItems[0].itemTypeInDB, $bucket.bucketName, $itemDesc, $month, $year, $bucketUsage, "TB" ,"U.1")
+            $this.addItem($entityId, $this.serviceBillingInfos.billedItems[0].itemTypeInDB, $bucket.bucketName, $itemDesc, $month, $year, $bucketUsage, "TB" ,"U.1") | Out-Null
 
 
         }# FIN parcours des buckets

--- a/powershell/include/MyNAS/MyNASACLUtils.inc.ps1
+++ b/powershell/include/MyNAS/MyNASACLUtils.inc.ps1
@@ -648,7 +648,7 @@
 
         $this.writeToLogAndHost("Adding rights to admin for server $server and username $username... ")
 
-        $output = $this.runFileACL("$userDir /G administrators:FSFF /sub /protect /force /files")
+        $this.runFileACL("$userDir /G administrators:FSFF /sub /protect /force /files") | Out-Null
 
     }
 
@@ -674,7 +674,7 @@
         $this.writeToLogAndHost("")
         $this.writeToLogAndHost("Removing rights to admin for server $server and username $username... ")
 
-        $output = $this.runFileACL("$userDir /R administrators /sub /protect /force /files")
+        $this.runFileACL("$userDir /R administrators /sub /protect /force /files") | Out-Null
 
         $this.writeToLogAndHost("Done")
     }

--- a/powershell/include/NameGenerator.inc.ps1
+++ b/powershell/include/NameGenerator.inc.ps1
@@ -648,8 +648,8 @@ class NameGenerator: NameGeneratorBase
             Throw ("Only supported for {0} tenant" -f $global:VRA_TENANT__RESEARCH)
         }
 
-        # Lorsque l'on utilise -match ou -notmatch, PowerShell initialise automatiquement une variable $matches avec les résultats du match
-        $dummy = $ADUserGroupName.ToLower() -match "([a-z_]+)_([0-9]+)"
+        # INFORMATION: Lorsque l'on utilise -match ou -notmatch, PowerShell initialise automatiquement une variable $matches avec les résultats du match
+        $ADUserGroupName.ToLower() -match "([a-z_]+)_([0-9]+)" | Out-Null
         return ("{0}_approval_{1}" -f $matches[1], $matches[2])
     }
 

--- a/powershell/include/REST/GroupsAPI.inc.ps1
+++ b/powershell/include/REST/GroupsAPI.inc.ps1
@@ -266,7 +266,7 @@ class GroupsAPI: RESTAPICurl
                                                                     $url, `
                                                                     (($defaultOptions.getEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join "&")
 
-        $dummy = $this.callAPI($uri, "POST", $null)
+        $this.callAPI($uri, "POST", $null) | Out-Null
 
         return $this.getGroupByName($name)
     }
@@ -306,7 +306,7 @@ class GroupsAPI: RESTAPICurl
     {
         $uri = "{0}&id={1}&newowner={2}" -f $this.getBaseURI('changeOwner'), $groupId, $ownerSciper
 
-        $group = $this.callAPI($uri, "POST", $null)
+        $this.callAPI($uri, "POST", $null) | Out-Null
     }
 
 
@@ -325,7 +325,7 @@ class GroupsAPI: RESTAPICurl
     {
         $uri = "{0}&id={1}&admin={2}" -f $this.getBaseURI('addAdmin'), $groupId, $adminSciper
 
-        $group = $this.callAPI($uri, "POST", $null)
+        $this.callAPI($uri, "POST", $null) | Out-Null
     }
 
 
@@ -356,7 +356,7 @@ class GroupsAPI: RESTAPICurl
     {
         $uri = "{0}&id={1}&admin={2}" -f $this.getBaseURI('removeAdmin'), $groupId, $adminSciper
 
-        $group = $this.callAPI($uri, "POST", $null)
+        $this.callAPI($uri, "POST", $null) | Out-Null
     }
 
 
@@ -410,7 +410,7 @@ class GroupsAPI: RESTAPICurl
     {
         $uri = "{0}&id={1}&member={2}" -f $this.getBaseURI('addMember'), $groupId, $memberSciper
 
-        $group = $this.callAPI($uri, "POST", $null)
+        $this.callAPI($uri, "POST", $null) | Out-Null
     }
     
     <#
@@ -439,7 +439,7 @@ class GroupsAPI: RESTAPICurl
     {
         $uri = "{0}&id={1}&member={2}" -f $this.getBaseURI('removeMember'), $groupId, $memberSciper
 
-        $group = $this.callAPI($uri, "POST", $null)
+        $this.callAPI($uri, "POST", $null) | Out-Null
     }
 
 

--- a/powershell/include/REST/NSXAPI.inc.ps1
+++ b/powershell/include/REST/NSXAPI.inc.ps1
@@ -131,7 +131,7 @@ class NSXAPI: RESTAPICurl
         $body = $this.createObjectFromJSON("nsx-nsgroup.json", $replace)
         
 		# Création du NS Group
-        $dummy = $this.callAPI($uri, "Post", $body)
+        $this.callAPI($uri, "Post", $body) | Out-Null
         
         # Retour du NS Group en le cherchant par son nom
         return $this.getNSGroupByName($name)
@@ -148,7 +148,7 @@ class NSXAPI: RESTAPICurl
     {
         $uri = "https://{0}/api/v1/ns-groups/{1}" -f $this.server, $nsGroup.id
 
-        $dummy = $this.callAPI($uri, "Delete", $null)
+        $this.callAPI($uri, "Delete", $null) | Out-Null
     }
 
 
@@ -292,7 +292,7 @@ class NSXAPI: RESTAPICurl
         $uri = "https://{0}/api/v1/firewall/sections/{1}" -f $this.server, $section.id
         
 		# Création de la section de firewall
-        $dummy = $this.callAPI($uri, "PUT", $section)       
+        $this.callAPI($uri, "PUT", $section) | Out-Null
         
     }
 
@@ -309,7 +309,7 @@ class NSXAPI: RESTAPICurl
         $uri = "https://{0}/api/v1/firewall/sections/{1}?cascade=true" -f $this.server, $id
         
 		# Création de la section de firewall
-        $dummy = $this.callAPI($uri, "Delete", $null)       
+        $this.callAPI($uri, "Delete", $null) | Out-Null
         
     }
 
@@ -410,7 +410,7 @@ class NSXAPI: RESTAPICurl
         $body = $this.createObjectFromJSON("nsx-firewall-section-rules.json", $replace)
 
         # Création des règles
-        $dummy = $this.callAPI($uri, "Post", $body)
+        $this.callAPI($uri, "Post", $body) | Out-Null
     }
 
 }

--- a/powershell/include/REST/RESTAPICurl.inc.ps1
+++ b/powershell/include/REST/RESTAPICurl.inc.ps1
@@ -172,7 +172,7 @@ class RESTAPICurl: RESTAPI
 		$nbCurlAttempts = 2
 		for($currentAttemptNo=1; $currentAttemptNo -le $nbCurlAttempts; $currentAttemptNo++)
 		{
-			$out = $this.curl.Start()
+			$this.curl.Start() | Out-Null
 
 			$output = $this.curl.StandardOutput.ReadToEnd()
 			$errorStr = $this.curl.StandardError.ReadToEnd()

--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -680,14 +680,14 @@ class NetAppAPI: RESTAPICurl
         BUT : Supprime un volume et attend que la tâche qui tourne en fond pour la création se
                 termine.
         
-        IN  : $id   -> ID du volume que l'on désire supprimer
+        IN  : $vol   -> objet représentant le volume à effacer
 	#>
-    [void] deleteVolume([string]$id)
+    [void] deleteVolume([PSObject]$vol)
     {
         # Recherche du serveur NetApp cible
-        $targetServer = $this.getServerForObject([NetAppObjectType]::Volume, $id)
+        $targetServer = $this.getServerForObject([NetAppObjectType]::Volume, $vol.uuid)
 
-        $uri = "https://{0}/api/storage/volumes/{1}" -f $targetServer, $id
+        $uri = "https://{0}/api/storage/volumes/{1}" -f $targetServer, $vol.uuid
 
         $result = $this.callAPI($uri, "DELETE", $null)
 

--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -207,10 +207,6 @@ class NetAppAPI: RESTAPICurl
         }
         else
         {
-            if($allRes.Count -eq 0)
-            {
-                return $null
-            }
             return $allRes
         }
         
@@ -570,13 +566,13 @@ class NetAppAPI: RESTAPICurl
         # Recherche du volume dans la liste
         $result = $this.getVolumeListQuery(("name={0}" -f $name))
 
-        if($null -eq $result)
+        if($result.count -eq 0)
         {
             return $null
         }
 
         # Recheche des détails du volume
-        return $this.getVolumeById($result.uuid)
+        return $this.getVolumeById($result[0].uuid)
     }
 
 
@@ -918,13 +914,13 @@ class NetAppAPI: RESTAPICurl
     {
         $result = $this.getExportPolicyListQuery( ("name={0}" -f $name) )
 
-        if($null -eq $result)
+        if($result.count -eq 0)
         {
             return $null
         }
 
         # Recheche des détails de l'export policy
-        return $this.getExportPolicyById($result.id)
+        return $this.getExportPolicyById($result[0].id)
     }
 
     <#
@@ -941,13 +937,13 @@ class NetAppAPI: RESTAPICurl
     {
         $result = $this.getExportPolicyListQuery( ("svm.name={0}&name={1}" -f $svm.name, $name) )
 
-        if($null -eq $result)
+        if($result.count -eq 0)
         {
             return $null
         }
 
         # Recheche des détails de l'export policy
-        return $this.getExportPolicyById($result.id)
+        return $this.getExportPolicyById($result[0].id)
     }
 
 
@@ -1078,11 +1074,6 @@ class NetAppAPI: RESTAPICurl
         # C'te bande de branquigoles chez NetApp... ils fournissent le nécessaire pour retourner les infos sur les export policies MAIS
         # ils ne remplissent pas les champs avec les valeurs dont on a besoin !!! bananes !!
         $this.getExportPolicyRuleListQuery($exportPolicy.id, "fields=clients,protocols,ro_rule,rw_rule,superuser") | ForEach-Object {
-
-            if($null -eq $_)
-            {
-                return
-            }
 
             # Si RO
             if($_.ro_rule[0] -eq "any")
@@ -1362,13 +1353,13 @@ class NetAppAPI: RESTAPICurl
     {
         $result = $this.getSnapshotPolicyListQuery( ("name={0}" -f $name) )
 
-        if($null -eq $result)
+        if($result.count -eq 0)
         {
             return $null
         }
 
         # Recheche des détails de l'export policy
-        return $this.getSnapshotPolicyById($result.uuid)
+        return $this.getSnapshotPolicyById($result[0].uuid)
     }
 
 

--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -791,13 +791,13 @@ class NetAppAPI: RESTAPICurl
 		-------------------------------------------------------------------------------------
         BUT : Retourne la liste des shares sur une SVM
 
-        IN  : $svmName  -> Nom de la SVM
+        IN  : $svm  -> Objet représentant la SVM
 
         RET : Liste des shares
 	#>
-    [Array] getSVMCIFSShareList([string]$svmName)
+    [Array] getSVMCIFSShareList([PSObject]$svm)
     {
-        return $this.getCIFSShareListQuery(("svm.name={0}" -f $svmName))
+        return $this.getCIFSShareListQuery(("svm.name={0}" -f $svm.name))
     }
 
 
@@ -805,13 +805,13 @@ class NetAppAPI: RESTAPICurl
 		-------------------------------------------------------------------------------------
         BUT : Retourne la liste des shares pour un volume
 
-        IN  : $volName  -> nom du volume
+        IN  : $vol  -> Objet représentant le volume
 
         RET : Liste des shares
 	#>
-    [Array] getVolCIFSShareList([string]$volName)
+    [Array] getVolCIFSShareList([PSObject]$vol)
     {
-        return $this.getCIFSShareListQuery(("volume.name={0}" -f $volName))
+        return $this.getCIFSShareListQuery(("volume.name={0}" -f $vol.name))
     }
 
 
@@ -1385,6 +1385,24 @@ class NetAppAPI: RESTAPICurl
         $body = $this.createObjectFromJSON("xaas-nas-patch-volume-snapshot-policy.json", $replace)
 
         $this.callAPI($uri, "PATCH", $body)
+    }
+
+
+    <#
+		-------------------------------------------------------------------------------------
+        BUT : Retourne la policy de snapshot d'un volume
+        
+        IN  : $vol   -> Objet représentant le volume
+
+        NOTE : L'appel à cette fonction ne retourne que les champs spécifiquement passés en paramètre.
+                Ce n'est donc pas comme si on pouvait juste "ajouter" des champs à ceux renvoyés par
+                défaut par l'appel retournant les détails d'un volume.
+	#>
+    [PSObject] getVolumeSnapshotPolicy([PSObject]$vol)
+    {
+        $uri = "/api/storage/volumes/{0}?fields=snapshot_policy.uuid" -f $vol.uuid
+
+        return $this.callAPI($uri, "GET", $null, "", $true)
     }
 
 

--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -779,13 +779,8 @@ class NetAppAPI: RESTAPICurl
 			$uri = "{0}&{1}" -f $uri, $queryParams
 		}
         
-        $list = $this.callAPI($uri, "GET", $null, "records")
-        # Si rien trouvé, on fait en sorte de retourner une liste vide plutôt que $null
-        if($null -eq $list)
-        {
-            return @()
-        }
-        return $list
+        return $this.callAPI($uri, "GET", $null, "records")
+        
     }
 
     

--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -783,7 +783,13 @@ class NetAppAPI: RESTAPICurl
 			$uri = "{0}&{1}" -f $uri, $queryParams
 		}
         
-        return $this.callAPI($uri, "GET", $null, "records")
+        $list = $this.callAPI($uri, "GET", $null, "records")
+        # Si rien trouvé, on fait en sorte de retourner une liste vide plutôt que $null
+        if($null -eq $list)
+        {
+            return @()
+        }
+        return $list
     }
 
     
@@ -968,7 +974,7 @@ class NetAppAPI: RESTAPICurl
 
         $body = $this.createObjectFromJSON("xaas-nas-new-export-policy.json", $replace)
 
-        $result = $this.callAPI($uri, "POST", $body)
+        $this.callAPI($uri, "POST", $body) | Out-Null
 
         # Retour de l'élément créé
         return $this.getExportPolicyByName($name)
@@ -1072,6 +1078,11 @@ class NetAppAPI: RESTAPICurl
         # C'te bande de branquigoles chez NetApp... ils fournissent le nécessaire pour retourner les infos sur les export policies MAIS
         # ils ne remplissent pas les champs avec les valeurs dont on a besoin !!! bananes !!
         $this.getExportPolicyRuleListQuery($exportPolicy.id, "fields=clients,protocols,ro_rule,rw_rule,superuser") | ForEach-Object {
+
+            if($null -eq $_)
+            {
+                return
+            }
 
             # Si RO
             if($_.ro_rule[0] -eq "any")

--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -529,7 +529,8 @@ class NetAppAPI: RESTAPICurl
         
         IN  : $vol   -> Objet représentant le volume
 
-        RET : "nfs3"|"cifs" Pour que ça puisse être réutilisé directement dans la fonction updateExportPolicyRules
+        RET : voir fichier include/XaaS/NAS/define.inc.ps1
+                $global:ACCESS_TYPE_* Pour que ça puisse être réutilisé directement dans la fonction updateExportPolicyRules
                 $null si pas trouvé
 	#>
     [string] getVolumeAccessProtocol([PSObject]$vol)
@@ -545,9 +546,9 @@ class NetAppAPI: RESTAPICurl
 
         if($vol.nas.security_style -eq "unix")
         {
-            return "nfs3"
+            return $global:ACCESS_TYPE_NFS3
         }
-        return "cifs"
+        return $global:ACCESS_TYPE_CIFS
     }
 
 
@@ -1157,7 +1158,8 @@ class NetAppAPI: RESTAPICurl
         IN  : $ROIPList         -> tableau avec la liste des IP Read-Only
         IN  : $RWIPList         -> Tableau avec la liste des IP Read-Write
         IN  : $RootIPList       -> Tableau avec la liste des IP Root
-        IN  : $protocol         -> "cifs"|"nfs3"
+        IN  : $protocol         -> Voir fichier include/XaaS/NAS/define.inc.ps1
+                                    $global:ACCESS_TYPE_*
 
 
         https://nas-mcc-t.epfl.ch/docs/api/#/NAS/export_rule_create
@@ -1185,7 +1187,7 @@ class NetAppAPI: RESTAPICurl
             $replace = @{
                 clientMatch = $ip.Trim()
                 roRule = "any"
-                protocol = $protocol.toString()
+                protocol = $protocol
             }
 
             # Si l'IP a ausi les accès Root

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -241,7 +241,7 @@ class vRAAPI: RESTAPICurl
 		}
 
 		# Création du BG
-		$res = $this.callAPI($uri, "Post", $body)
+		$this.callAPI($uri, "Post", $body) | Out-Null
 		
 		# Recherche et retour du BG
 		# On utilise $body.name et pas simplement $name dans le cas où il y aurait un préfixe ou suffixe de nom déjà hard-codé dans 
@@ -353,7 +353,7 @@ class vRAAPI: RESTAPICurl
 		}
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Put", $bg)
+		$this.callAPI($uri, "Put", $bg) | Out-Null
 		
 		# On recherche l'objet mis à jour
 		return $this.getBG($bg.name)
@@ -382,7 +382,7 @@ class vRAAPI: RESTAPICurl
 		
 		$bg.extensionData.entries = $entries
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Put", $bg)
+		$this.callAPI($uri, "Put", $bg) | Out-Null
 
 		# On recherche l'objet mis à jour
 		return $this.getBG($bg.name)
@@ -401,7 +401,7 @@ class vRAAPI: RESTAPICurl
 		$uri = "https://{0}/identity/api/tenants/{1}/subtenants/{2}" -f $this.server, $this.tenant, $bgId
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Delete", $null)
+		$this.callAPI($uri, "Delete", $null) | Out-Null
 	}
 
 
@@ -459,7 +459,7 @@ class vRAAPI: RESTAPICurl
 			$uri = "https://{0}/identity/api/tenants/{1}/subtenants/{2}/roles/{3}/" -f $this.server, $this.tenant, $BGID, $role
 
 			# Suppression du contenu du rôle
-			$res = $this.callAPI($uri, "Delete", $null)
+			$this.callAPI($uri, "Delete", $null) | Out-Null
 		}
 
 	}
@@ -513,7 +513,7 @@ class vRAAPI: RESTAPICurl
 		)
 
 		# Ajout du rôle
-		$res = $this.callAPI($uri, "Post", $body)
+		$this.callAPI($uri, "Post", $body) | Out-Null
 		
 	}
 
@@ -645,7 +645,7 @@ class vRAAPI: RESTAPICurl
 
 		$body = $this.createObjectFromJSON("vra-entitlement.json", $replace)
 
-		$res = $this.callAPI($uri, "Post", $body)
+		$this.callAPI($uri, "Post", $body) | Out-Null
 		
 		# Retour de l'entitlement
 		# On utilise $body.name et pas simplement $name dans le cas où il y aurait un préfixe ou suffixe de nom déjà hard-codé dans 
@@ -704,7 +704,7 @@ class vRAAPI: RESTAPICurl
 		}
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Put", $ent)
+		$this.callAPI($uri, "Put", $ent) | Out-Null
 		
 		# on retourne spécifiquement l'objet qui est dans vRA et pas seulement celui qu'on a utilisé pour faire la mise à jour. Ceci
 		# pour la simple raison que dans certains cas particuliers, on se retrouve avec des erreurs "409 Conflicts" si on essaie de
@@ -747,7 +747,7 @@ class vRAAPI: RESTAPICurl
 	{
 		$uri = "https://{0}/catalog-service/api/entitlements/{1}" -f $this.server, $entId
 
-		$res = $this.callAPI($uri, "Delete", $null)
+		$this.callAPI($uri, "Delete", $null) | Out-Null
 	}
 
 	<#
@@ -1011,7 +1011,7 @@ class vRAAPI: RESTAPICurl
 		# On l'active (dans le cas où le Template était désactivé)
 		$resTemplate.enabled = $true
 
-		$res = $this.callAPI($uri, "Post", $resTemplate)
+		$this.callAPI($uri, "Post", $resTemplate) | Out-Null
 		
 		return $this.getRes($name)
 
@@ -1072,7 +1072,7 @@ class vRAAPI: RESTAPICurl
 	{
 		$uri = "https://{0}/reservation-service/api/reservations/{1}" -f $this.server, $resID
 
-		$res = $this.callAPI($uri, "Delete", $null)
+		$this.callAPI($uri, "Delete", $null) | Out-Null
 		
 	}
 
@@ -1339,7 +1339,7 @@ class vRAAPI: RESTAPICurl
 		#>
 		$uri = "https://{0}/iaas-proxy-provider/api/machine-prefixes/guid'{1}'" -f $this.server, $machinePrefix.id
 
-		$dummy = $this.callAPI($uri, "DELETE", $null)
+		$this.callAPI($uri, "DELETE", $null) | Out-Null
 	}
 
 
@@ -1380,7 +1380,7 @@ class vRAAPI: RESTAPICurl
 		{
 			# On filtre pour ne retourner que les éléments qui n'ont pas de parents car on ne veut pas les trucs
 			# genre "yum_update" ou autre.
-			$result = $result |  Where-Object { $_.parentResourceRef -eq $null}
+			$result = $result |  Where-Object { $null -eq $_.parentResourceRef}
 		}
 
 		return $result
@@ -1475,7 +1475,7 @@ class vRAAPI: RESTAPICurl
 	{
 		$uri = "https://{0}/identity/api/tenants/{1}/directories/{2}/sync" -f $this.server, $this.tenant, $name
 
-		$res = $this.callAPI($uri, "Post", $null)
+		$this.callAPI($uri, "Post", $null) | Out-Null
 	}
 
 
@@ -1604,7 +1604,7 @@ class vRAAPI: RESTAPICurl
 		$body = $this.createObjectFromJSON($approvalPolicyJSON, $replace)
 
 		# Création de la Policy
-		$res = $this.callAPI($uri, "Post", $body)
+		$this.callAPI($uri, "Post", $body) | Out-Null
 
 		# On utilise $body.name et pas simplement $name dans le cas où il y aurait un préfixe ou suffixe de nom déjà hard-codé dans 
 		# le fichier JSON template
@@ -1654,7 +1654,7 @@ class vRAAPI: RESTAPICurl
 		}
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Put", $approvalPolicy)
+		$this.callAPI($uri, "Put", $approvalPolicy) | Out-Null
 
 		# on retourne spécifiquement l'objet qui est dans vRA et pas seulement celui qu'on a utilisé pour faire la mise à jour. Ceci
 		# pour la simple raison que dans certains cas particuliers, on se retrouve avec des erreurs "409 Conflicts" si on essaie de
@@ -1679,7 +1679,7 @@ class vRAAPI: RESTAPICurl
 		$uri = "https://{0}/approval-service/api/policies/{1}" -f $this.server, $approvalPolicy.id
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Delete", $null)
+		$this.callAPI($uri, "Delete", $null) | Out-Null
 		
 	}
 
@@ -1812,7 +1812,7 @@ class vRAAPI: RESTAPICurl
 		# Mise à jour de la description, bien qu'elle n'apparaîtra nulle part...
 		$actionTemplate.description = "Automatic Backup Tag Update"
 
-		$dummy = $this.callAPI($uri, "Post", $actionTemplate)
+		$this.callAPI($uri, "Post", $actionTemplate) | Out-Null
 
 	}
 

--- a/powershell/include/REST/vSphereAPI.inc.ps1
+++ b/powershell/include/REST/vSphereAPI.inc.ps1
@@ -175,7 +175,7 @@ class vSphereAPI: RESTAPICurl
 
 		$body = $this.createObjectFromJSON("vsphere-tag-operation.json", $replace)
 
-		$res = $this.callAPI($uri, "Post", $body)
+		$this.callAPI($uri, "Post", $body) | Out-Null
 	}
 
 

--- a/powershell/include/XaaS/NAS/NameGeneratorNAS.inc.ps1
+++ b/powershell/include/XaaS/NAS/NameGeneratorNAS.inc.ps1
@@ -163,6 +163,7 @@ class NameGeneratorNAS: NameGeneratorBase
       return $forVolumeName
    }
 
+
    <#
 		-------------------------------------------------------------------------------------
 		BUT : Renvoie la regex à utiliser pour chercher un nom de volume Collaboratif
@@ -171,7 +172,7 @@ class NameGeneratorNAS: NameGeneratorBase
 
       RET : La regex
 	#>
-   [string] getCollaborativeVolRegex([bool]$isNFS)
+   [string] getCollaborativeVolDetailedRegex([bool]$isNFS)
    {
       $regex = ("{0}_{1}_[0-9]_files" -f $this.details.faculty, $this.details.unit)
 
@@ -180,7 +181,33 @@ class NameGeneratorNAS: NameGeneratorBase
          $regex = "{0}_nfs" -f $regex
       }
 
-      return $regex
+      return ("^{0}$" -f $regex)
+   }
+
+
+   <#
+		-------------------------------------------------------------------------------------
+		BUT : Renvoie le type d'un volume en fonction de son nom
+
+      IN  : $volName -> Nom du volume
+
+      RET : Type du volume
+	#>
+   [XaaSNASVolType] getVolumeType([string]$volName)
+   {
+      # Collaboratif
+      if([Regex]::Match($volName, '^(.*?)_files(_nfs)?$').Success)
+      {
+         return [XaaSNASVolType]::col
+      }
+
+      # Applicatif¨
+      if([Regex]::Match($volName, '^(.*?)_app$'))
+      {
+         return [XaaSNASVolType]::app
+      }
+      
+      Throw ("Impossible to determine volume type for volume name '{0}'" -f $volName)
    }
         
 }

--- a/powershell/include/XaaS/NAS/NameGeneratorNAS.inc.ps1
+++ b/powershell/include/XaaS/NAS/NameGeneratorNAS.inc.ps1
@@ -117,6 +117,42 @@ class NameGeneratorNAS: NameGeneratorBase
 
    <#
 		-------------------------------------------------------------------------------------
+		BUT : Renvoie le chemin de montage d'un volume en fonction de son protocol
+
+      IN  : $volName       -> Le nom du volume
+      IN  : $svm           -> Nom de la SVM
+      IN  : $protocol      -> Protocol d'accès
+                              voir dans include/XaaS/NAS/define.inc.ps1
+                              $global:ACCESS_TYPE_*
+
+      RET : Le chemin de montage
+	#>
+   [string] getVolMountPath([string]$volName, [string]$svm, [string]$protocol)
+   {
+      $mountPath = switch($protocol)
+      {
+         $global:ACCESS_TYPE_CIFS
+         {
+            "\\{0}\{1}" -f $svm, $volName
+         }
+
+         $global:ACCESS_TYPE_NFS3
+         {
+            "{0}:/{1}" -f $svm, $volName
+         }
+
+         default
+         {
+            Throw ("Protcol '{0}' not handled" -f $protocol)
+         }
+      }
+
+      return $mountPath
+   }
+
+
+   <#
+		-------------------------------------------------------------------------------------
 		BUT : Renvoie le nom de l'export policy à utiliser pour le volume
 
       IN  : $forVolumeName -> Nom du volume pour lequel on veut le nom de l'export policy

--- a/powershell/include/XaaS/NAS/NameGeneratorNAS.inc.ps1
+++ b/powershell/include/XaaS/NAS/NameGeneratorNAS.inc.ps1
@@ -121,29 +121,28 @@ class NameGeneratorNAS: NameGeneratorBase
 
       IN  : $volName       -> Le nom du volume
       IN  : $svm           -> Nom de la SVM
-      IN  : $protocol      -> Protocol d'accès
-                              voir dans include/XaaS/NAS/define.inc.ps1
-                              $global:ACCESS_TYPE_*
+      IN  : $protocol      -> Protocol d'accès. Tel que défini dans le fichier de la classe
+                              [NetAppAPI] 
 
       RET : Le chemin de montage
 	#>
-   [string] getVolMountPath([string]$volName, [string]$svm, [string]$protocol)
+   [string] getVolMountPath([string]$volName, [string]$svm, [NetAppProtocol]$protocol)
    {
       $mountPath = switch($protocol)
       {
-         $global:ACCESS_TYPE_CIFS
+         cifs
          {
             "\\{0}\{1}" -f $svm, $volName
          }
 
-         $global:ACCESS_TYPE_NFS3
+         nfs3
          {
             "{0}:/{1}" -f $svm, $volName
          }
 
          default
          {
-            Throw ("Protcol '{0}' not handled" -f $protocol)
+            Throw ("Protcol '{0}' not handled" -f $protocol.toString())
          }
       }
 

--- a/powershell/include/XaaS/NAS/define.inc.ps1
+++ b/powershell/include/XaaS/NAS/define.inc.ps1
@@ -5,5 +5,9 @@
    DATE   : Octobre 2020
 #>
 
-# Les types d'accès possibles 
+# lettre à utiliser pour monter le drive réseau pour initialiser les droits
 $global:XAAS_NAS_TEMPORARY_DRIVE = "Z"
+
+# Les types d'accès possibles 
+$global:ACCESS_TYPE_CIFS    = "cifs"
+$global:ACCESS_TYPE_NFS3    = "nfs3"

--- a/powershell/include/XaaS/NAS/define.inc.ps1
+++ b/powershell/include/XaaS/NAS/define.inc.ps1
@@ -7,3 +7,10 @@
 
 # lettre à utiliser pour monter le drive réseau pour initialiser les droits
 $global:XAAS_NAS_TEMPORARY_DRIVE = "Z"
+
+# Types de volumes qu'on peut avoir sur le NAS
+# Si on appelle la fonction "ToString()" sur l'un d'eux, ça doit renvoyer ce qui est passé en paramètre du script "endpoint"
+Enum XaaSNASVolType {
+   col # Collaboratif
+   app # Applicatif
+}

--- a/powershell/include/XaaS/NAS/define.inc.ps1
+++ b/powershell/include/XaaS/NAS/define.inc.ps1
@@ -7,7 +7,3 @@
 
 # lettre à utiliser pour monter le drive réseau pour initialiser les droits
 $global:XAAS_NAS_TEMPORARY_DRIVE = "Z"
-
-# Les types d'accès possibles 
-$global:ACCESS_TYPE_CIFS    = "cifs"
-$global:ACCESS_TYPE_NFS3    = "nfs3"

--- a/powershell/include/functions.inc.ps1
+++ b/powershell/include/functions.inc.ps1
@@ -102,7 +102,7 @@ function ADGroupExists([string]$groupName)
 	try
 	{
 		# On tente de récupérer le groupe (on met dans une variable juste pour que ça ne s'affiche pas à l'écran)
-		$adGroup = Get-ADGroup -Identity $groupName
+		Get-ADGroup -Identity $groupName | Out-Null
 		# Si on a pu le récupérer, c'est qu'il existe.
 		return $true
 
@@ -264,7 +264,7 @@ function convertHTMLtoPDF([string] $source, [string]$destinationFile, [string] $
 	$pdfDocument.Open()
 
 	# Ajout de l'auteur. Ceci ne peut être fait qu'à partir du moment où le document PDF a été ouvert (via 'Open() )
-	$dummy = $pdfDocument.AddAuthor($author)
+	$pdfDocument.AddAuthor($author) | Out-Null
 	
 	
 	# On tente de charger le HTML dans le document PDF 
@@ -305,7 +305,7 @@ function saveRESTError([string]$category, [string]$errorId, [string]$errorMsg, [
 {
     $errorFolder =  ([IO.Path]::Combine($global:ERROR_FOLDER, $category, $errorId))
 
-    $dummy = New-Item -ItemType "directory" -Path $errorFolder
+    New-Item -ItemType "directory" -Path $errorFolder | Out-Null
 
     $jsonContent | Out-File ([IO.Path]::Combine($errorFolder, "REST.json"))
 

--- a/powershell/mynas-process-hd-actions-requests.ps1
+++ b/powershell/mynas-process-hd-actions-requests.ps1
@@ -84,7 +84,7 @@ function setActionStatus
    
    #Write-Host "setUserDeleted: $url"
    # Appel de l'URL pour initialiser l'utilisateur comme renommé 
-   $res = getWebPageLines -url $url
+   getWebPageLines -url $url | Out-Null
 }
 
 

--- a/powershell/mynas-process-infos-from-cadi.ps1
+++ b/powershell/mynas-process-infos-from-cadi.ps1
@@ -144,7 +144,7 @@ try
          # On regarde si l'utilisateur se trouve dans AD. Si ce n'est pas le cas, on passe au suivant, tout en ayant loggué la chose.
          try
          {
-            $ADuser = Get-ADUser -Identity $user.username -Properties *
+            Get-ADUser -Identity $user.username -Properties * | Out-Null
          }
          catch
          {

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -249,7 +249,7 @@ function removeInexistingADAccounts([Array] $accounts)
 	{
 		try 
 		{
-			$m = Get-ADUser $acc
+			Get-ADUser $acc | Out-Null
 
 			# Si on arrive ici, c'est que pas d'erreur donc compte trouvé.
 			$validAccounts += $acc
@@ -346,7 +346,7 @@ function updateVRAUsersForBG([SQLDB]$sqldb, [Array]$userList, [TableauRoles]$rol
 
 	# On commence par supprimer tous les utilisateurs du role donné pour le BG
 	$request = "DELETE FROM vraUsers WHERE role='{0}' AND {1}" -f $role, ($criteriaConditions -join " AND ")
-	$nbDeleted = $sqldb.execute($request)
+	$sqldb.execute($request) | Out-Null
 
 	$baseRequest = "INSERT INTO vraUsers VALUES"
 	$rows = @()
@@ -367,7 +367,7 @@ function updateVRAUsersForBG([SQLDB]$sqldb, [Array]$userList, [TableauRoles]$rol
 		{
 			# On créé la requête et on l'exécute
 			$request = "{0}{1}" -f $baseRequest, ($rows -join ",")
-			$nbInserted = $sqldb.execute($request)
+			$sqldb.execute($request) | Out-Null
 			$rows = @()
 		}
 		
@@ -377,7 +377,7 @@ function updateVRAUsersForBG([SQLDB]$sqldb, [Array]$userList, [TableauRoles]$rol
 	if($rows.Count -gt 0)
 	{
 		$request = "{0}{1}" -f $baseRequest, ($rows -join ",")
-		$nbInserted = $sqldb.execute($request)
+		$sqldb.execute($request) | Out-Null
 	}
 
 	
@@ -767,7 +767,7 @@ try
 					try
 					{
 						# On tente de récupérer le groupe (on met dans une variable juste pour que ça ne s'affiche pas à l'écran)
-						$adGroup = Get-ADGroup -Identity $adGroupName
+						Get-ADGroup -Identity $adGroupName | Out-Null
 
 						$adGroupExists = $true
 						$logHistory.addLineAndDisplay(("--> Group exists ({0}) " -f $adGroupName))

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -71,7 +71,7 @@ param ( [string]$targetEnv, [string]$targetTenant, [switch]$fullSync, [switch]$r
 . ([IO.Path]::Combine("$PSScriptRoot", "include", "NotificationMail.inc.ps1"))
 . ([IO.Path]::Combine("$PSScriptRoot", "include", "EPFLLDAP.inc.ps1"))
 . ([IO.Path]::Combine("$PSScriptRoot", "include", "ResumeOnFail.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "EPFLLDAP.inc.ps1"))
+
 
 # Chargement des fichiers pour API REST
 . ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "APIUtils.inc.ps1"))
@@ -723,7 +723,7 @@ function createOrUpdateBGReservations
 		if($null -eq $matchingRes)
 		{
 			$logHistory.addLineAndDisplay(("--> Adding Reservation '{0}' from template '{1}'..." -f $resName, $resTemplate.name))
-			$dummy = $vra.addResFromTemplate($resTemplate, $resName, $bg.tenant, $bg.id)
+			$vra.addResFromTemplate($resTemplate, $resName, $bg.tenant, $bg.id) | Out-Null
 
 			$counters.inc('ResCreated')
 		}
@@ -1362,9 +1362,6 @@ try
 	# Création de l'objet pour récupérer les informations sur les approval policies à créer pour les demandes de nouveaux éléments
 	$newItems = [NewItems]::new("vra-new-items.json")
 
-	# Pour rechercher dans LDAP
-	$ldap = [EPFLLDAP]::new()
-
 	# Création de l'objet pour gérer les 2nd day actions
 	$secondDayActions = [SecondDayActions]::new()
 
@@ -1656,7 +1653,7 @@ try
 		{
 			$logHistory.addLineAndDisplay(("--> Creating ISO folder '{0}'..." -f $bgISOFolder))
 			# On le créé
-			$dummy = New-Item -Path $bgISOFolder -ItemType:Directory
+			New-Item -Path $bgISOFolder -ItemType:Directory | Out-Null
 
 			# Pour faire en sorte que les ACLs soient mises à jour.
 			$ISOFolderCreated = $true
@@ -1732,7 +1729,7 @@ try
 		elseif($isBGOfType -and ($doneBGList -notcontains $_.name))
 		{
 			$logHistory.addLineAndDisplay(("-> Setting Business Group '{0}' as Ghost..." -f $_.name))
-			$setAsGhost = setBGAsGhostIfNot -vra $vra -bg $_
+			setBGAsGhostIfNot -vra $vra -bg $_ | Out-Null
 
 		}
 

--- a/powershell/vsphere-update-vm-notes.ps1
+++ b/powershell/vsphere-update-vm-notes.ps1
@@ -132,12 +132,11 @@ try
     # Chargement des modules PowerCLI pour pouvoir accéder à vSphere.
     loadPowerCliModules
 
-    # Pour éviter que le script parte en erreur si le certificat vCenter ne correspond pas au nom DNS primaire. On met le résultat dans une variable
-    # bidon sinon c'est affiché à l'écran.
-    $dummy = Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -Confirm:$false
+    # Pour éviter que le script parte en erreur si le certificat vCenter ne correspond pas au nom DNS primaire.
+    Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -Confirm:$false | Out-Null
 
     # Pour éviter la demande de rejoindre le programme de "Customer Experience"
-    $dummy = Set-PowerCLIConfiguration -Scope User -ParticipateInCEIP $false -Confirm:$false
+    Set-PowerCLIConfiguration -Scope User -ParticipateInCEIP $false -Confirm:$false | Out-Null
 
     # Connexion au serveur vSphere
 
@@ -162,7 +161,7 @@ try
         {
             $logHistory.addLineAndDisplay("{0} Updating" -f $logLine)
 
-            $dummy = Set-Vm $vm -Notes $newNote -Confirm:$false
+            Set-Vm $vm -Notes $newNote -Confirm:$false | Out-Null
             $counters.inc('VMNotesUpdated')
         }
         else # Pas besoin de mettre à jour. 

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -109,10 +109,6 @@ $ACTION_GET_VOL_INFOS       = "getVolInfos"
 
 $global:APP_VOL_DEFAULT_FAC = "si"
 
-# Type de volume
-$global:VOL_TYPE_COLL       = "col"
-$global:VOL_TYPE_APP        = "app"
-
 # Limites
 $global:MAX_VOL_PER_UNIT    = 9
 
@@ -465,7 +461,7 @@ try
             switch($volType)
             {
                 # ---- Volume Applicatif
-                $global:VOL_TYPE_APP
+                ([XaaSNASVolType]::app).ToString()
                 {
                     $nameGeneratorNAS.setApplicativeDetails($global:APP_VOL_DEFAULT_FAC, $volName)
 
@@ -487,7 +483,7 @@ try
                 }
 
                 # ---- Volume Collaboratif
-                $global:VOL_TYPE_COLL
+                ([XaaSNASVolType]::col).ToString()
                 {
                     # Check des valeurs passées pour les snapshots
                     if( (($snapPercent -eq 0) -and ($snapPolicy -ne "")) -or ( ($snapPercent -ne 0) -and ($snapPolicy -eq "") ))
@@ -580,7 +576,7 @@ try
                     switch($volType)
                     {
                         # ---- Volume Applicatif
-                        $global:VOL_TYPE_APP
+                        ([XaaSNASVolType]::app).ToString()
                         {
                             # Ajout de l'export policy
                             $exportPol, $null = addNFSExportPolicy -nameGeneratorNAS $nameGeneratorNAS -netapp $netapp -volumeName $volName -svmObj $svmObj `
@@ -588,7 +584,7 @@ try
                         }
 
                         # ---- Volume Collaboratif
-                        $global:VOL_TYPE_COLL
+                        ([XaaSNASVolType]::col).ToString()
                         {
                             $logHistory.addLine(("Checking if Export Policy '{0}' exists on SVM '{1}'..." -f $global:EXPORT_POLICY_DENY_NFS_ON_CIFS, $svmObj.name))
                             $exportPol = $netapp.getExportPolicyByName($svmObj, $global:EXPORT_POLICY_DENY_NFS_ON_CIFS)
@@ -670,7 +666,7 @@ try
             # 3. Politique de snapshot
 
             # Si volume collaboratif ET qu'il faut avoir les snapshots
-            if(( $volType -eq $global:VOL_TYPE_COLL) -and $snapPolicy -ne "")
+            if(( $volType -eq ([XaaSNASVolType]::col).ToString()) -and $snapPolicy -ne "")
             {
                 $snapPolicyObj = $netapp.getSnapshotPolicyByName($snapPolicy)
                 if($null -eq $snapPolicyObj)

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -526,12 +526,12 @@ try
             # En fonction du type d'accès qui a été demandé
             switch($access.toLower())
             {
-                "cifs"
+                ([NetAppProtocol]::cifs).ToString()
                 {
                     $securityStyle = "ntfs"
                 }
 
-                "nfs3"
+                ([NetAppProtocol]::nfs3).ToString()
                 {
                     $securityStyle = "unix"
                 }
@@ -568,7 +568,7 @@ try
             switch($access.toLower())
             {
                 # ------------ CIFS
-                "cifs"
+                ([NetAppProtocol]::cifs).ToString()
                 {
                     $logHistory.addLine( ("Adding CIFS share '{0}' to point on '{1}'..." -f $volName, $mountPoint))
                     $netapp.addCIFSShare($volName, $svmObj, $mountPoint)
@@ -655,7 +655,7 @@ try
 
 
                 # ------------ NFS
-                "nfs3"
+                ([NetAppProtocol]::nfs3).ToString()
                 {
                     # Ajout de l'export policy
                     $exportPol, $result = addNFSExportPolicy -nameGeneratorNAS $nameGeneratorNAS -netapp $netapp -volumeName $volName -svmObj $svmObj `

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -118,12 +118,10 @@ $global:ACCESS_TYPE_CIFS    = "cifs"
 $global:ACCESS_TYPE_NFS3    = "nfs3"
 
 # Limites
-$global:MAX_VOL_PER_UNIT    = 10
+$global:MAX_VOL_PER_UNIT    = 9
 
 # Autre
 $global:EXPORT_POLICY_DENY_NFS_ON_CIFS = "deny_nfs_on_cifs"
-$global:SNAPSHOT_POLICY = "epfl-default"
-$global:SNAPSHOT_SPACE_PERCENT = 30
 
 <#
     -------------------------------------------------------------------------------------

--- a/powershell/xaas-s3-endpoint.ps1
+++ b/powershell/xaas-s3-endpoint.ps1
@@ -175,7 +175,7 @@ try
                 $logHistory.addLine("Creating bucket {0}..." -f $bucketInfos.bucketName)
 
                 # Création du bucket
-                $s3Bucket = $scality.addBucket($bucketInfos.bucketName)
+                $scality.addBucket($bucketInfos.bucketName) | Out-Null
 
                 $bucketInfos.access = @{}
 


### PR DESCRIPTION
- On doit maintenant passer `-snapPercent` et `-snapPolicy` (au lieu de `-withSnap`) pour les infos de snapshots d'un volume
- Ajout d'une option d'utilisation `getVolInfos` qui retourne plein d'informations sur un volume. Format décrit sur Confluence: https://confluence.epfl.ch:8443/display/SIAC/%5BXaaS%5D+-+NAS+-+xaas-nas-endpoint.ps1
- Mise à jour des "usage" pour supprimer les valeurs non possibles pour `targetTenant` en fonction des paramètres de l'action demandée
- Utilisation de types `enum` pour les protocoles d'accès (NFS/CIFS) ainsi que les types de volumes (collaboratif/applicatif)
- Corrections diverses
   - Utilisation de `Out-Null` au lieu d'assigner des variables jamais utilisées
- Correction d'un bug qui faisait que si on demandait à créer un volume qui existe déjà, celui-ci était effacé 😲
