### PR TITLE
XaaS NAS Billing - Part 1

### DIFF
--- a/powershell/data/billing/nas/service.json
+++ b/powershell/data/billing/nas/service.json
@@ -7,7 +7,6 @@
     [
         {
             "itemTypeInDB": "NAS Volume",
-            "itemDescPrefix":"NAS Volume",
             "copernicPrestationCode":
             {
                 "test": "??",

--- a/powershell/data/billing/nas/service.json
+++ b/powershell/data/billing/nas/service.json
@@ -12,7 +12,7 @@
                 "test": "9010260",
                 "prod": "9010260"
             },
-            "entityTypesPriceLevels":
+            "entityTypesMonthlyPriceLevels":
             {
                 "Unit":
                 {

--- a/powershell/data/billing/nas/service.json
+++ b/powershell/data/billing/nas/service.json
@@ -1,6 +1,6 @@
 {
     "billingClassName": "BillingNASVolume",
-    "docTitle": "Rapport mensuel de consommation de Volumes « NAS Volume »",
+    "docTitle": "Rapport mensuel de consommation de Volumes NAS",
     "serviceName": "NAS",
     "landscapePDF": true,
     "billedItems":
@@ -9,8 +9,8 @@
             "itemTypeInDB": "NAS Volume",
             "copernicPrestationCode":
             {
-                "test": "??",
-                "prod": "??"
+                "test": "9010260",
+                "prod": "9010260"
             },
             "entityTypesPriceLevels":
             {
@@ -32,7 +32,7 @@
     "billingReference": "christophe.simond@epfl.ch",
     "billingGrid": 
     {
-        "Project": "billing-grid.pdf"
+        "Project": ""
     },
     "itemColumns":
     {

--- a/powershell/data/billing/nas/service.json
+++ b/powershell/data/billing/nas/service.json
@@ -1,0 +1,60 @@
+{
+    "billingClassName": "BillingNASVolume",
+    "docTitle": "Rapport mensuel de consommation de Volumes « NAS Volume »",
+    "serviceName": "NAS",
+    "landscapePDF": true,
+    "billedItems":
+    [
+        {
+            "itemTypeInDB": "NAS Volume",
+            "itemDescPrefix":"NAS Volume",
+            "copernicPrestationCode":
+            {
+                "test": "??",
+                "prod": "??"
+            },
+            "entityTypesPriceLevels":
+            {
+                "Unit":
+                {
+                    "U.1": 7.5
+                },
+                "Project":
+                {
+                    "U.1": 0,
+                    "U.2": 0,
+                    "U.3": 0
+                }
+            }
+        }
+    ],
+    "pdfAuthor": "EPFL SI SI-EXOP",
+    "billingFrom": "VPSI",
+    "billingReference": "christophe.simond@epfl.ch",
+    "billingGrid": 
+    {
+        "Project": "billing-grid.pdf"
+    },
+    "itemColumns":
+    {
+        "colCode": "Code prestation",
+        "colDesc": "Description",
+        "colMonthYear": "Consommé le [mois]",
+        "colConsumed": "Quantité",
+        "colUnit": "Unité",
+        "colUnitPrice": "Prix unitaire HT [CHF]",
+        "colTotPrice": "Prix total HT [CHF]"
+    },
+    "copernic":
+    {
+        "shipperName": "Christophe Simond",
+        "shipperSciper": "287589",
+        "shipperFund": "1914-1",
+        "shipperMail": "christophe.simond@epfl.ch",
+        "shipperPhone": "0216931068",
+
+        "shipperImputationNoBilledSVC": "SVC0075"
+        
+    }
+    
+}

--- a/powershell/data/billing/s3/service.json
+++ b/powershell/data/billing/s3/service.json
@@ -12,7 +12,7 @@
                 "test": "9010390",
                 "prod": "9010390"
             },
-            "entityTypesPriceLevels":
+            "entityTypesMonthlyPriceLevels":
             {
                 "Unit":
                 {

--- a/powershell/data/billing/s3/service.json
+++ b/powershell/data/billing/s3/service.json
@@ -7,7 +7,6 @@
     [
         {
             "itemTypeInDB": "S3 Bucket",
-            "itemDescPrefix":"Object Storage S3",
             "copernicPrestationCode":
             {
                 "test": "9010390",

--- a/powershell/data/billing/service-sample.json
+++ b/powershell/data/billing/service-sample.json
@@ -12,7 +12,7 @@
                 "test": "",
                 "prod": ""
             },
-            "entityTypesPriceLevels": // prix unitaire, par mois, pour chaque type d'entité défini dans ../../include/Billing.inc.ps1. Si un type d'entité n'est pas présent ici, il ne sera pas facturé
+            "entityTypesMonthlyPriceLevels": // prix unitaire, par mois, pour chaque type d'entité défini dans ../../include/Billing.inc.ps1. Si un type d'entité n'est pas présent ici, il ne sera pas facturé
             {
                 "Unit":
                 {

--- a/powershell/data/billing/service-sample.json
+++ b/powershell/data/billing/service-sample.json
@@ -7,7 +7,6 @@
     [
         {
             "itemTypeInDB": "", // Type de l'item à facturer, pour le classifier dans la DB
-            "itemDescPrefix":"", // Préfix à ajouter à la description de chaque item quand on l'ajoute dans la table BillingItem via la classe enfante dédiée à ça
             "copernicPrestationCode": // nom de code de l'article dans Copernic, peut varier entre prod et test.
             {
                 "test": "",

--- a/powershell/include/Billing.inc.ps1
+++ b/powershell/include/Billing.inc.ps1
@@ -18,12 +18,6 @@
    0.1 - Version de base
 
 #>
-enum EntityType 
-{
-    Unit
-    Service
-    Project
-}
 
 class Billing
 {
@@ -73,7 +67,7 @@ class Billing
         RET : Objet avec les infos de l'entité 
             $null si pas trouvé
     #>
-    hidden [PSObject] getEntity([EntityType]$type, [string]$element)
+    hidden [PSObject] getEntity([BillingEntityType]$type, [string]$element)
     {
         $request = "SELECT * FROM BillingEntity WHERE entityType='{0}' AND entityElement='{1}'" -f $type, $element
 
@@ -96,7 +90,7 @@ class Billing
 
         RET : ID de l'entité
     #>
-    hidden [int] addEntity([EntityType]$type, [string]$element, [string]$financeCenter)
+    hidden [int] addEntity([BillingEntityType]$type, [string]$element, [string]$financeCenter)
     {
         $entity = $this.getEntity($type, $element)
 
@@ -129,7 +123,7 @@ class Billing
                                     OU
                                     adresse mail à laquelle envoyer la facture
     #>
-    hidden [void] updateEntity([int]$id, [EntityType]$type, [string]$element, [string]$financeCenter)
+    hidden [void] updateEntity([int]$id, [BillingEntityType]$type, [string]$element, [string]$financeCenter)
     {
         # L'entité n'existe pas, donc on l'ajoute 
         $request = "UPDATE BillingEntity SET entityType='{0}', entityElement='{1}', entityFinanceCenter='{2}' WHERE entityId={3}" -f `
@@ -213,7 +207,7 @@ class Billing
 
         RET : Description
     #>
-    hidden [string] getEntityElementDesc([EntityType]$entityType, [string]$entityElement)
+    hidden [string] getEntityElementDesc([BillingEntityType]$entityType, [string]$entityElement)
     {
         switch($entityType)
         {
@@ -255,7 +249,7 @@ class Billing
 
         RET : Centre financier. Numéro ou adresse mail
     #>
-    hidden [string] getEntityElementFinanceCenter([EntityType]$entityType, [string]$entityElement)
+    hidden [string] getEntityElementFinanceCenter([BillingEntityType]$entityType, [string]$entityElement)
     {
         switch($entityType)
         {

--- a/powershell/include/BillingS3Bucket.inc.ps1
+++ b/powershell/include/BillingS3Bucket.inc.ps1
@@ -61,11 +61,11 @@ class BillingS3Bucket: Billing
         # On va utiliser le champ "unitOrSvcID"
         if($bucketInfos.unitOrSvcID -match $this.entityMatchUnit)
         {
-            return [EntityType]::Unit
+            return [BillingEntityType]::Unit
         }
         if($bucketInfos.unitOrSvcID -match $this.entityMatchSvc)
         {
-            return [EntityType]::Service
+            return [BillingEntityType]::Service
         }
         # Si on arrive ici, c'est que ce n'est pas géré donc on renvoie $null
         return $null
@@ -136,16 +136,16 @@ class BillingS3Bucket: Billing
             {
                 Continue
             }
-            elseif($entityType -eq [EntityType]::Service)
+            elseif($entityType -eq [BillingEntityType]::Service)
             {
                 Write-Warning ("Skipping Service entity ({0}) because not billed" -f $bucket.bucketName)
                 Continue
             }
-            elseif($entityType -eq [EntityType]::Unit)
+            elseif($entityType -eq [BillingEntityType]::Unit)
             {
                 $targetTenant = $global:VRA_TENANT__EPFL
             }
-            elseif($entityType -eq [EntityType]::Project)
+            elseif($entityType -eq [BillingEntityType]::Project)
             {
                 $targetTenant = $global:VRA_TENANT__RESEARCH
             }

--- a/powershell/include/define.inc.ps1
+++ b/powershell/include/define.inc.ps1
@@ -117,3 +117,10 @@ $global:XAAS_BILLING_ITEM_DOCUMENT_TEMPLATE = ([IO.Path]::Combine("$PSScriptRoot
 $global:XAAS_BILLING_MAIL_TEMPLATE = ([IO.Path]::Combine("$PSScriptRoot", "..", "resources", "billing", "xaas-billing-mail.html"))
 $global:XAAS_BILLING_PDF_FOLDER = ([IO.Path]::Combine("$PSScriptRoot", "..", "billing"))
 
+# Type d'entité à facturer
+enum BillingEntityType 
+{
+    Unit
+    Service
+    Project
+}

--- a/powershell/include/functions.inc.ps1
+++ b/powershell/include/functions.inc.ps1
@@ -329,3 +329,22 @@ function objectPropertyExists([PSCustomObject]$obj, [string]$propertyName)
 {
 	return ((($obj).PSobject.Properties | Select-Object -ExpandProperty "Name") -contains $propertyName)
 }
+
+
+<#
+    -------------------------------------------------------------------------------------
+    BUT : Renvoie le type d'entité de facturation en fonction du tenant
+    
+    IN  : $tenant   -> Nom du tenant
+
+    RET : Type d'entité, type [BillingEntityType]. Défini dans le fichier include/define.inc.ps1
+#>
+function getBillingEntityTypeFromTenant([string]$tenant)
+{
+    switch($tenant)
+    {
+        $global:VRA_TENANT__EPFL { return [BillingEntityType]::Unit }
+        $global:VRA_TENANT__ITSERVICES { return [BillingEntityType]::Service }
+        $global:VRA_TENANT__RESEARCH { return [BillingEntityType]::Project }
+    }
+}

--- a/powershell/xaas-billing.ps1
+++ b/powershell/xaas-billing.ps1
@@ -403,7 +403,7 @@ try
                 {
 
                     # Si on n'a pas d'infos de facturation pour le type d'entité courante, on ne va pas plus loin, on traite ça comme une erreur
-                    if(!(objectPropertyExists -obj $billedItemInfos.entityTypesPriceLevels -propertyName $entity.entityType))
+                    if(!(objectPropertyExists -obj $billedItemInfos.entityTypesMonthlyPriceLevels -propertyName $entity.entityType))
                     {
                         Throw ("Error for item type '{0}' because no billing info found for entity '{1}'. Have a look at billing JSON configuration file for service '{2}'" -f $billedItemInfos.itemTypeInDB, $entity.entityType, $service)
                     }
@@ -420,7 +420,7 @@ try
                     {
 
                         # Si on n'a pas d'infos de niveau de facturation (niveau de prix) pour l'item courant, on passe au suivant
-                        if(!(objectPropertyExists -obj $billedItemInfos.entityTypesPriceLevels.($entity.entityType) -propertyName $item.itemPriceLevel))
+                        if(!(objectPropertyExists -obj $billedItemInfos.entityTypesMonthlyPriceLevels.($entity.entityType) -propertyName $item.itemPriceLevel))
                         {
                             Throw ("Error for item type '{0}' because price level '{1}' not found in JSON configuration file for service '{2}'" -f $item.itemType, $item.itemPriceLevel, $service)
                         }
@@ -437,7 +437,7 @@ try
                         # être réutilisé plus loin dans le code qui ajoute la facture dans Copernic.
                         # On récupère la valeur via "Select-Object" car le nom du niveau peut contenir des caractères non alphanumériques qui sont
                         # donc incompatibles avec un nom de propriété accessible de manière "standard" ($obj.<propertyName>)
-                        $unitPricePerMonthCHF = $billedItemInfos.entityTypesPriceLevels.($entity.entityType) | Select-Object -ExpandProperty $item.itemPriceLevel
+                        $unitPricePerMonthCHF = $billedItemInfos.entityTypesMonthlyPriceLevels.($entity.entityType) | Select-Object -ExpandProperty $item.itemPriceLevel
                         $item | Add-member -NotePropertyName "unitPricePerMonthCHF" -NotePropertyValue $unitPricePerMonthCHF
 
                         $monthYear = (getItemDateMonthYear -month $item.itemMonth -year $item.itemYear)

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -1098,7 +1098,7 @@ try
             }
 
             # Si on n'a pas d'infos de facturation pour le type d'entité, on ne va pas plus loin, on traite ça comme une erreur
-            if(!(objectPropertyExists -obj $billedItemInfos.entityTypesPriceLevels -propertyName $entityType))
+            if(!(objectPropertyExists -obj $billedItemInfos.entityTypesMonthlyPriceLevels -propertyName $entityType))
             {
                 Throw ("Error for item type '{0}' because no billing info found for entity '{1}'. Have a look at billing JSON configuration file for NAS service ({2})" -f `
                         $itemType, $entityType, $serviceBillingInfosFile)
@@ -1106,7 +1106,7 @@ try
 
             $priceLevel = "U.{0}" -f $userFeeLevel
             # Si on n'a pas d'infos de facturation pour le niveau demandé, on ne va pas plus loin, on traite ça comme une erreur
-            if(!(objectPropertyExists -obj $billedItemInfos.entityTypesPriceLevels.$entityType -propertyName $priceLevel))
+            if(!(objectPropertyExists -obj $billedItemInfos.entityTypesMonthlyPriceLevels.$entityType -propertyName $priceLevel))
             {
                 Throw ("Error for item type '{0}' and entity '{1}' because no billing info found for level '{2}'. Have a look at billing JSON configuration file for NAS service ({3})" -f `
                         $itemType, $entityType, $priceLevel, $serviceBillingInfosFile)
@@ -1114,7 +1114,7 @@ try
             
             # On récupère la valeur via "Select-Object" car le nom du niveau peut contenir des caractères non alphanumériques qui sont
             # donc incompatibles avec un nom de propriété accessible de manière "standard" ($obj.<propertyName>)
-            $TBPricePerMonth = $billedItemInfos.entityTypesPriceLevels.$entityType | Select-Object -ExpandProperty $priceLevel
+            $TBPricePerMonth = $billedItemInfos.entityTypesMonthlyPriceLevels.$entityType | Select-Object -ExpandProperty $priceLevel
             
             # Calcul de la taille que le volume devrait faire avec les snaps
             $sizeWithSnapGB = getCorrectVolumeSize -requestedSizeGB $sizeGB -snapSpacePercent $snapPercent


### PR DESCRIPTION
Permière partie de la facturation NAS
- Création du fichier décrivant le service à facturer (`data/billing/nas/service.json`) 
- Ajout d'une commande permettant de renvoyer le prix prix qui serait facturé pour un volume en fonction de sa taille et du pourcentage de snapshot à réserver
- Changement d'un nom de type énuméré
- Suppression d'une information dans les fichiers JSON de description de service à facturer (plus utilisée)
- Changement du nom d'un champ dans le fichier JSON décrivant le service à facturer afin que ça soit plus clair que le prix exprimé est pour un mois.


Cette PR va être mergée dans l'état et les opérations suivantes restent à faire:
- Création de la classe permettant de facturer des volumes NAS