### PR TITLE
XaaS S3 - Billing fix

### DIFF
--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -175,6 +175,7 @@ class vRAAPI: RESTAPICurl
 		return $this.getBGListQuery(("`$filter=substringof('{0}', name)" -f $str))
 	}
 
+
 	<#
 		-------------------------------------------------------------------------------------
 		BUT : Renvoie un BG donné par son nom
@@ -190,6 +191,32 @@ class vRAAPI: RESTAPICurl
 
 		if($list.Count -eq 0){return $null}
 		return $list[0]
+	}
+
+
+	<#
+		-------------------------------------------------------------------------------------
+		BUT : Renvoie un BG donné par son ID custom, défini dans la custom property ch.epfl.vra.bg.id
+
+		IN  : $customId	-> ID custom du BG que l'on désire
+
+		RET : Objet contenant le BG
+				$null si n'existe pas
+	#>
+	[PSCustomObject] getBGByCustomId([string] $customId)
+	{
+		$list = $this.getBGList()
+
+		if($list.Count -eq 0){return $null}
+		
+		# Retour en cherchant avec le custom ID, y'a pas mal de Where-Object imbriqués pour faire le job mais ça fonctionne. Par contre, 
+		# ça risque d'être un peu galère à debug par la suite ^^'
+		return $list| Where-Object { 
+			($_.extensionData.entries | Where-Object {
+				$null -ne ($_.key -eq $global:VRA_CUSTOM_PROP_EPFL_BG_ID) -and ( $null -ne ($_.value.values.entries | Where-Object { 
+					$_.value.value -eq $customId } ) ) `
+													} `
+			)}
 	}
 
 

--- a/powershell/include/billing/BillingNASVolume.inc.ps1
+++ b/powershell/include/billing/BillingNASVolume.inc.ps1
@@ -138,12 +138,13 @@ class BillingNASVolume: Billing
             }
             
             # On ajoute ou met à jour l'entité dans la DB et on retourne son ID
-            $entityId = $this.initAndGetEntityId($entityType, $volume.targetTenant, $volume.bgName, $volume.volId)
+            $entityId = $this.initAndGetEntityId($entityType, $volume.targetTenant, $volume.bgId, $volume.volId)
 
             # Si on n'a pas trouvé l'entité, c'est que n'a pas les infos nécessaires pour l'ajouter à la DB
             if($entityId -eq 0)
             {
-                Write-Warning ("Business Group '{0}' ('{1}') has been deleted and item '{2}' wasn't existing last month. Not enough information to bill it" -f $volume.bgName, $volume.targetTenant, $volume.volName)
+                Write-Warning ("Business Group '{0}' with ID {1} ('{2}') has been deleted and item '{3}' wasn't existing last month. Not enough information to bill it" -f `
+                                $entityType.toString(), $volume.bgId, $volume.targetTenant, $volume.volName)
                 Continue
             }
             

--- a/powershell/include/billing/BillingS3Bucket.inc.ps1
+++ b/powershell/include/billing/BillingS3Bucket.inc.ps1
@@ -131,11 +131,13 @@ class BillingS3Bucket: Billing
 
             $targetTenant = $null
 
-            # Si pas supporté, on passe à l'élément suivant
+            # Si pas supporté, on passe à l'élément suivant. 
             # NOTE: on n'utilise pas de "switch" car l'utilisation de "Continue" n'est pas possible au sein de celui-ci...
             # On n'utilise pas non plus la valeur "targetTenant" présente dans la table BucketArchive car elle ne correspond pas au tenant vRA réel
             if($null -eq $entityType)
             {
+                # Si on arrive ici, c'est que ce n'est pas supporté ou que potentiellement le champ svcOrUnitId ne contient pas une valeur correcte,
+                # ce qui peut arriver dans l'environnement de test (et prod) parce qu'on met un peu tout et n'importe quoi dans svcOrUnitId...
                 Continue
             }
             elseif($entityType -eq [BillingEntityType]::Service)
@@ -153,12 +155,13 @@ class BillingS3Bucket: Billing
             }
 
             # On ajoute ou met à jour l'entité dans la DB et on retourne son ID
-            $entityId = $this.initAndGetEntityId($entityType, $targetTenant, $bucket.bgName, $bucket.bucketName)
+            $entityId = $this.initAndGetEntityId($entityType, $targetTenant, $bucket.unitOrSvcID, $bucket.bucketName)
 
             # Si on n'a pas trouvé l'entité, c'est que n'a pas les infos nécessaires pour l'ajouter à la DB
             if($null -eq $entityId)
             {
-                Write-Warning ("Business Group '{0}' ('{1}') has been deleted and item '{2}' wasn't existing last month. Not enough information to bill it" -f $bucket.bgName, $targetTenant, $bucket.bucketName)
+                Write-Warning ("Business Group '{0}' with ID {1} ('{2}') has been deleted and item '{3}' wasn't existing last month. Not enough information to bill it" -f `
+                                $entityType.toString(), $bucket.unitOrSvcID, $targetTenant, $bucket.bucketName)
                 Continue
             }
 

--- a/powershell/include/define.inc.ps1
+++ b/powershell/include/define.inc.ps1
@@ -55,7 +55,6 @@ $global:VRA_SERVICE_SUFFIX__PRIVATE =" (Private)"
 
 # Nom des custom properties à utiliser
 $global:VRA_CUSTOM_PROP_EPFL_BG_ID                    = "ch.epfl.vra.bg.id"
-$global:VRA_CUSTOM_PROP_EPFL_PROJECT_ID               = "ch.epfl.project.id"
 $global:VRA_CUSTOM_PROP_VRA_BG_TYPE                   = "ch.epfl.vra.bg.type"
 $global:VRA_CUSTOM_PROP_VRA_BG_STATUS                 = "ch.epfl.vra.bg.status"
 $global:VRA_CUSTOM_PROP_VRA_BG_RES_MANAGE             = "ch.epfl.vra.bg.res.manage"


### PR DESCRIPTION
Utilisation de l'ID du BG (`ch.epfl.vra.bg.id`) à la place du nom, car le nom peut changer dans le temps.
Dans le cas de figure suivant:
1. Création du BG
1. Demande de bucket
1. Renommage du BG
1. Processus de facturation

Tous les buckets demandés avant le renommage du BG et avant le premier cycle de facturation ne seront jamais facturés car on utilisait le nom du BG pour le rechercher dans vRA et comme il n'était pas trouvable, aucune facturation n'intervenait pour le bucket.