### PR TITLE
Some cleaning

### DIFF
--- a/powershell/clean-ghost-bg.ps1
+++ b/powershell/clean-ghost-bg.ps1
@@ -92,7 +92,7 @@ function deleteBGAndComponentsIfPossible([vRAAPI]$vra, [GroupsAPI]$groupsApp, [N
 
 		$counters.inc('BGNotEmpty')
 
-		$notifications['bgNotDeleted'] += $bg.name
+		$notifications.bgNotDeleted += $bg.name
 
 		$deleted = $false
 
@@ -127,7 +127,7 @@ function deleteBGAndComponentsIfPossible([vRAAPI]$vra, [GroupsAPI]$groupsApp, [N
 		}
 
 		
-		$notifications['bgDeleted'] += $bg.name
+		$notifications.bgDeleted += $bg.name
 
 		# --------------
 		# Business Group
@@ -183,7 +183,7 @@ function deleteBGAndComponentsIfPossible([vRAAPI]$vra, [GroupsAPI]$groupsApp, [N
 				catch
 				{
 					# Si exception, c'est qu'on n'a probablement pas les droits d'effacer parce que le owner du groupe n'est pas le bon
-					$notifications['groupsGroupsNotDeleted'] += $approveGroupGroupsInfos.name
+					$notifications.groupsGroupsNotDeleted += $approveGroupGroupsInfos.name
 					$logHistory.addWarningAndDisplay("--> Cannot delete groups group maybe because not owner by correct person")
 				}
 
@@ -229,7 +229,7 @@ function deleteBGAndComponentsIfPossible([vRAAPI]$vra, [GroupsAPI]$groupsApp, [N
 			catch
 			{
 				# Si exception, c'est qu'on n'a probablement pas les droits d'effacer parce que le owner du groupe n'est pas le bon
-				$notifications['groupsGroupsNotDeleted'] += $userSharedGroupNameGroups
+				$notifications.groupsGroupsNotDeleted += $userSharedGroupNameGroups
 				$logHistory.addWarningAndDisplay("--> Cannot delete groups group maybe because not owner by correct person")
 			}
 
@@ -288,10 +288,10 @@ function handleNotifications
 	ForEach($notif in $notifications.Keys)
 	{
 		# S'il y a des notifications de ce type
-		if($notifications[$notif].count -gt 0)
+		if($notifications.$notif.count -gt 0)
 		{
 			# Suppression des doublons 
-			$uniqueNotifications = $notifications[$notif] | Sort-Object| Get-Unique
+			$uniqueNotifications = $notifications.$notif | Sort-Object| Get-Unique
 
 			$valToReplace = @{}
 

--- a/powershell/mynas-process-user-rename-requests.ps1
+++ b/powershell/mynas-process-user-rename-requests.ps1
@@ -97,10 +97,10 @@ function handleNotifications
 	ForEach($notif in $notifications.Keys)
 	{
 		# S'il y a des notifications de ce type
-		if($notifications[$notif].count -gt 0)
+		if($notifications.$notif.count -gt 0)
 		{
 			# Suppression des doublons 
-			$uniqueNotifications = $notifications[$notif] | Sort-Object| Get-Unique
+			$uniqueNotifications = $notifications.$notif | Sort-Object| Get-Unique
 
 			$valToReplace = @{}
 

--- a/powershell/mynas-process-waiting-quota-update-requests.ps1
+++ b/powershell/mynas-process-waiting-quota-update-requests.ps1
@@ -86,10 +86,10 @@ function handleNotifications
 	ForEach($notif in $notifications.Keys)
 	{
 		# S'il y a des notifications de ce type
-		if($notifications[$notif].count -gt 0)
+		if($notifications.$notif.count -gt 0)
 		{
 			# Suppression des doublons 
-			$uniqueNotifications = $notifications[$notif] | Sort-Object| Get-Unique
+			$uniqueNotifications = $notifications.$notif | Sort-Object| Get-Unique
 
 			$valToReplace = @{}
 

--- a/powershell/resources/json-templates/vra-user-credentials.json
+++ b/powershell/resources/json-templates/vra-user-credentials.json
@@ -1,5 +1,5 @@
 {	
-		username : "{{username}}",
-		password : "{{password}}",
-		tenant : "{{tenant}}"
+		"username" : "{{username}}",
+		"password" : "{{password}}",
+		"tenant" : "{{tenant}}"
 }

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -505,11 +505,11 @@ try
 	
 	# Pour accéder à la base de données
 	$sqldb = [SQLDB]::new([DBType]::MSSQL, `
-							$configVra.getConfigValue($targetEnv, "dbmssql", "host"), `
-							$configVra.getConfigValue($targetEnv, "dbmssql", "dbName"), `
-							$configVra.getConfigValue($targetEnv, "dbmssql", "user"), `
-							$configVra.getConfigValue($targetEnv, "dbmssql", "password"), `
-							$configVra.getConfigValue($targetEnv, "dbmssql", "port"))
+							$configVra.getConfigValue($targetEnv, "db", "host"), `
+							$configVra.getConfigValue($targetEnv, "db", "dbName"), `
+							$configVra.getConfigValue($targetEnv, "db", "user"), `
+							$configVra.getConfigValue($targetEnv, "db", "password"), `
+							$configVra.getConfigValue($targetEnv, "db", "port"))
 
 	Import-Module ActiveDirectory
 

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -149,10 +149,10 @@ function handleNotifications([System.Collections.IDictionary] $notifications, [s
 	ForEach($notif in $notifications.Keys)
 	{
 		# S'il y a des notifications de ce type
-		if($notifications[$notif].count -gt 0)
+		if($notifications.$notif.count -gt 0)
 		{
 			# Suppression des doublons 
-			$uniqueNotifications = $notifications[$notif] | Sort-Object| Get-Unique
+			$uniqueNotifications = $notifications.$notif | Sort-Object| Get-Unique
 
 			$valToReplace = @{}
 
@@ -636,10 +636,10 @@ try
 					if((createADGroupWithContent -groupName $approveGroupInfos.name -groupDesc $approveGroupDescAD -groupMemberGroup $approveGroupNameGroups `
 						-OU $nameGenerator.getADGroupsOUDN($approveGroupInfos.onlyForTenant) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
 					{
-						if($notifications['missingEPFLADGroups'] -notcontains $approveGroupNameGroups)
+						if($notifications.missingEPFLADGroups -notcontains $approveGroupNameGroups)
 						{
 							# Enregistrement du nom du groupe qui pose problème et passage à la faculté suivante car on ne peut pas créer celle-ci
-							$notifications['missingEPFLADGroups'] += $approveGroupNameGroups
+							$notifications.missingEPFLADGroups += $approveGroupNameGroups
 						}
 						$allGroupsOK = $false
 					}
@@ -672,7 +672,7 @@ try
 					-OU $nameGenerator.getADGroupsOUDN($true) -simulation $SIMULATION_MODE -updateExistingContent $false) -eq $false)
 				{
 					# Enregistrement du nom du groupe qui pose problème et passage à la faculté suivante car on ne peut pas créer celle-ci
-					$notifications['missingEPFLADGroups'] += $adminGroupNameGroups
+					$notifications.missingEPFLADGroups += $adminGroupNameGroups
 					break
 				}
 				# Enregistrement du groupe créé pour ne pas le supprimer à la fin du script...
@@ -683,7 +683,7 @@ try
 					-OU $nameGenerator.getADGroupsOUDN($true) -simulation $SIMULATION_MODE -updateExistingContent $false) -eq $false)
 				{
 					# Enregistrement du nom du groupe qui pose problème et passage à la faculté suivante car on ne peut pas créer celle-ci
-					$notifications['missingEPFLADGroups'] += $supportGroupNameGroups
+					$notifications.missingEPFLADGroups += $supportGroupNameGroups
 					break
 				}
 				# Enregistrement du groupe créé pour ne pas le supprimer à la fin du script...
@@ -1037,9 +1037,9 @@ try
 						-OU $nameGenerator.getADGroupsOUDN($approveGroupInfos.onlyForTenant) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
 					{
 						# Enregistrement du nom du groupe qui pose problème et on note de passer au service suivant car on ne peut pas créer celui-ci
-						if($notifications['missingITSADGroups'] -notcontains $approveGroupNameGroups)
+						if($notifications.missingITSADGroups -notcontains $approveGroupNameGroups)
 						{
-							$notifications['missingITSADGroups'] += $approveGroupNameGroups
+							$notifications.missingITSADGroups += $approveGroupNameGroups
 						}
 							
 						$allGroupsOK = $false
@@ -1068,7 +1068,7 @@ try
 					 -OU $nameGenerator.getADGroupsOUDN($true) -simulation $SIMULATION_MODE -updateExistingContent $false) -eq $false)
 				{
 					# Enregistrement du nom du groupe qui pose problème et passage au service suivant car on ne peut pas créer celui-ci
-					$notifications['missingITSADGroups'] += $admSupGroupNameGroups
+					$notifications.missingITSADGroups += $admSupGroupNameGroups
 					continue
 				}
 				# Enregistrement du groupe créé pour ne pas le supprimer à la fin du script...
@@ -1097,9 +1097,9 @@ try
 					 -OU $nameGenerator.getADGroupsOUDN($true) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
 				{
 					# Enregistrement du nom du groupe qui pose problème et passage au service suivant car on ne peut pas créer celui-ci
-					if($notifications['missingADGroups'] -notcontains $userSharedGroupNameGroupsAD)
+					if($notifications.missingADGroups -notcontains $userSharedGroupNameGroupsAD)
 					{
-						$notifications['missingADGroups'] += $userSharedGroupNameGroupsAD
+						$notifications.missingADGroups += $userSharedGroupNameGroupsAD
 					}
 				}
 				else
@@ -1218,9 +1218,9 @@ try
 						-OU $nameGenerator.getADGroupsOUDN($approveGroupInfos.onlyForTenant) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
 					{
 						# Enregistrement du nom du groupe qui pose problème et on note de passer au service suivant car on ne peut pas créer celui-ci
-						if($notifications['missingADGroups'] -notcontains $approveGroupNameGroupsAD)
+						if($notifications.missingADGroups -notcontains $approveGroupNameGroupsAD)
 						{
-							$notifications['missingADGroups'] += $approveGroupNameGroupsAD
+							$notifications.missingADGroups += $approveGroupNameGroupsAD
 						}
 							
 						$allApproveGroupsOK = $false
@@ -1250,7 +1250,7 @@ try
 					 -OU $nameGenerator.getADGroupsOUDN($true) -simulation $SIMULATION_MODE -updateExistingContent $false) -eq $false)
 				{
 					# Enregistrement du nom du groupe qui pose problème et passage au service suivant car on ne peut pas créer celui-ci
-					$notifications['missingRSRCHADGroups'] += $admSupGroupNameGroups
+					$notifications.missingRSRCHADGroups += $admSupGroupNameGroups
 					$roleAdmSupGroupOK = $false
 				}
 				else
@@ -1281,9 +1281,9 @@ try
 					 -OU $nameGenerator.getADGroupsOUDN($true) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
 				{
 					# Enregistrement du nom du groupe qui pose problème et passage au service suivant car on ne peut pas créer celui-ci
-					if($notifications['missingADGroups'] -notcontains $userSharedGroupNameGroupsAD)
+					if($notifications.missingADGroups -notcontains $userSharedGroupNameGroupsAD)
 					{
-						$notifications['missingADGroups'] += $userSharedGroupNameGroupsAD
+						$notifications.missingADGroups += $userSharedGroupNameGroupsAD
 					}
 					$roleSharedGroupOk = $false
 				}

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -421,7 +421,7 @@ function createOrUpdateBG
 					$logHistory.addErrorAndDisplay(("-> Error renaming folder. Error is : {0}" -f $_.Error.Message))
 				
 					# Ajout d'information dans les notifications pour faire en sorte que les admins soient informés par mail.
-					$notifications['ISOFolderNotRenamed'] += ("{0} -> {1}" -f $bgISOFolderCurrent, $bgISOFolderNew)
+					$notifications.ISOFolderNotRenamed += ("{0} -> {1}" -f $bgISOFolderCurrent, $bgISOFolderNew)
 
 					# On continue ensuite l'exécution normalement 
 				}
@@ -777,7 +777,7 @@ function setBGAsGhostIfNot
 	# Si le BG est toujours actif
 	if(isBGAlive -bg $bg)
 	{
-		$notifications['bgSetAsGhost'] += $bg.name
+		$notifications.bgSetAsGhost += $bg.name
 
 		# On marque le BG comme "Ghost"
 		$vra.updateBG($bg, $null, $null, $null, @{"$global:VRA_CUSTOM_PROP_VRA_BG_STATUS" = $global:VRA_BG_STATUS__GHOST})
@@ -844,7 +844,7 @@ function isBGAlive
 	<# Si on arrive ici, c'est qu'on n'a pas défini de clef (pour une raison inconnue) pour enregistrer le statut
 	   On enregistre donc la chose et on dit que le BG est "vivant"
 	#>
-	$notifications['bgWithoutCustomPropStatus'] += $bg.name
+	$notifications.bgWithoutCustomPropStatus += $bg.name
 	return $true
 }
 
@@ -868,10 +868,10 @@ function handleNotifications
 	ForEach($notif in $notifications.Keys)
 	{
 		# S'il y a des notifications de ce type
-		if($notifications[$notif].count -gt 0)
+		if($notifications.$notif.count -gt 0)
 		{
 			# Suppression des doublons 
-			$uniqueNotifications = $notifications[$notif] | Sort-Object| Get-Unique
+			$uniqueNotifications = $notifications.$notif | Sort-Object| Get-Unique
 
 			$valToReplace = @{}
 
@@ -987,7 +987,7 @@ function checkIfADGroupsExists
 				{
 					$logHistory.addWarningAndDisplay(("Security group '{0}' not found in Active Directory" -f $groupName))
 					# Enregistrement du nom du groupe
-					$notifications['adGroupsNotFound'] += $groupName
+					$notifications.adGroupsNotFound += $groupName
 					$allOK = $false
 				}
 				else # Le groupe est OK
@@ -1571,7 +1571,7 @@ try
 		if((Get-ADGroupMember -server ad2.epfl.ch $_.Name).Count -eq 0)
 		{
 			# On enregistre l'info pour notification
-			$notifications['emptyADGroups'] += ("{0} ({1})" -f $_.Name, $bgName)
+			$notifications.emptyADGroups += ("{0} ({1})" -f $_.Name, $bgName)
 		}
 
 		
@@ -1722,7 +1722,7 @@ try
 		# Si la custom property qui donne les infos n'a pas été trouvée
 		if($null -eq $isBGOfType)
 		{
-			$notifications['bgWithoutCustomPropType'] += $_.name
+			$notifications.bgWithoutCustomPropType += $_.name
 			$logHistory.addLineAndDisplay(("-> Custom Property '{0}' not found in Business Group '{1}'..." -f $global:VRA_CUSTOM_PROP_VRA_BG_TYPE, $_.name))
 		}
 		elseif($isBGOfType -and ($doneBGList -notcontains $_.name))

--- a/powershell/xaas-billing.ps1
+++ b/powershell/xaas-billing.ps1
@@ -155,10 +155,10 @@ function handleNotifications([System.Collections.IDictionary] $notifications, [s
 	ForEach($notif in $notifications.Keys)
 	{
 		# S'il y a des notifications de ce type
-		if($notifications[$notif].count -gt 0)
+		if($notifications.$notif.count -gt 0)
 		{
 			# Suppression des doublons 
-			$uniqueNotifications = $notifications[$notif] | Sort-Object| Get-Unique
+			$uniqueNotifications = $notifications.$notif | Sort-Object| Get-Unique
 
 			$valToReplace = @{
                 serviceName = $serviceName

--- a/powershell/xaas-billing.ps1
+++ b/powershell/xaas-billing.ps1
@@ -276,11 +276,11 @@ try
 
     # Pour accéder à la base de données
 	$sqldb = [SQLDB]::new([DBType]::MSSQL, `
-                        $configVra.getConfigValue($targetEnv, "dbmssql", "host"), `
-                        $configVra.getConfigValue($targetEnv, "dbmssql", "dbName"), `
-                        $configVra.getConfigValue($targetEnv, "dbmssql", "user"), `
-                        $configVra.getConfigValue($targetEnv, "dbmssql", "password"), `
-                        $configVra.getConfigValue($targetEnv, "dbmssql", "port"))
+                        $configVra.getConfigValue($targetEnv, "db", "host"), `
+                        $configVra.getConfigValue($targetEnv, "db", "dbName"), `
+                        $configVra.getConfigValue($targetEnv, "db", "user"), `
+                        $configVra.getConfigValue($targetEnv, "db", "password"), `
+                        $configVra.getConfigValue($targetEnv, "db", "port"))
 
     $ldap = [EPFLLDAP]::new()
 

--- a/powershell/xaas-s3-endpoint.ps1
+++ b/powershell/xaas-s3-endpoint.ps1
@@ -128,10 +128,10 @@ function handleNotifications
 	ForEach($notif in $notifications.Keys)
 	{
 		# S'il y a des notifications de ce type
-		if($notifications[$notif].count -gt 0)
+		if($notifications.$notif.count -gt 0)
 		{
 			# Suppression des doublons 
-			$uniqueNotifications = $notifications[$notif] | Sort-Object| Get-Unique
+			$uniqueNotifications = $notifications.$notif | Sort-Object| Get-Unique
 
 			$valToReplace = @{}
 


### PR DESCRIPTION
- Changement du champ `dbmssql` en `db` dans le fichier de configuration `config-vra.json` (#114 )
- Correction de syntaxe dans un fichier
- Changement de la manière dont on accèdes les éléments contenus dans le dictionnaire `$notifications` présent dans plusieurs scripts #120 

# Mise en production
- Editer le fichier `config-vra.json`
   - Virer la partie `db`
   - Renommer `dbmssql` en `db`