### PR TITLE
Improve REST logging

### DIFF
--- a/powershell/.gitignore
+++ b/powershell/.gitignore
@@ -7,3 +7,4 @@ test-*.ps1
 *.progress
 ./xaas/
 filesToPush
+*.debug

--- a/powershell/include/LogHistory.inc.ps1
+++ b/powershell/include/LogHistory.inc.ps1
@@ -116,4 +116,15 @@ class LogHistory
         Write-Warning $line
         $this.addLine(("!!WARNING!! {0}" -f $line))
     }
+
+    <#
+	-------------------------------------------------------------------------------------
+        BUT : Ajoute une ligne au fichier Log pour dire que c'est du DEBUG
+
+        IN  : $line -> La ligne à ajouter
+	#>
+	[void] addDebug([string]$line)
+	{
+        $this.addLine(("!!DEBUG!! {0}" -f $line))
+    }
 }

--- a/powershell/include/REST/APIUtils.inc.ps1
+++ b/powershell/include/REST/APIUtils.inc.ps1
@@ -16,10 +16,15 @@ class APIUtils
 	# Pour compter le nombre d'appels aux fonctions de la classe
 	hidden [Counters] $funcCalls
 
-	# Pour avoir un cache local pour certaines fonctions, ceci afin d'éviter de faire milliards d'appels aux APIs
-	# Certains éléments ne changent en effet pas via le script donc sont en "read only" en quelque sorte. Pour 
-	# ceux-ci, on peut se permettre d'avoir un cache local pour aller plus vite.
+	<# Pour avoir un cache local pour certaines fonctions, ceci afin d'éviter de faire milliards d'appels aux APIs
+		Certains éléments ne changent en effet pas via le script donc sont en "read only" en quelque sorte. Pour 
+		ceux-ci, on peut se permettre d'avoir un cache local pour aller plus vite. #>
 	hidden [Array] $cache
+
+	<# Objet de la classe LogHistory dans le cas où on voudrait faire du logging "verbose" de ce qui se passe.
+		Il faudra utiliser la fonction 'activateDebug()' pour activer ce logging en passant l'objet de la 
+		classe LogHistory #>
+	hidden [LogHistory] $logHistory
 
     <#
 	-------------------------------------------------------------------------------------
@@ -29,6 +34,8 @@ class APIUtils
     {
 		$this.funcCalls = [Counters]::new()
 		$this.cache = @()
+
+		$this.logHistory = $null
 	}
 
 	
@@ -133,7 +140,7 @@ class APIUtils
 	{
 		return $this.funcCalls.getDisplay($title)
 	}
-
+	
 
 	<#
 		-------------------------------------------------------------------------------------
@@ -207,6 +214,44 @@ class APIUtils
 		catch
 		{
 			Throw ("Error converting JSON from file ({0})" -f $filepath)
+		}
+	}
+
+
+	<#
+		-------------------------------------------------------------------------------------
+		BUT : Activation du logging "debug" des requêtes faites sur le système distant.
+
+		IN  : $logHistory	-> Objet de la classe LogHistory qui va permettre de faire le logging.
+	#>
+	[void] activateDebug([LogHistory]$logHistory)
+	{
+		$this.logHistory = $logHistory
+	}
+
+
+	<#
+		-------------------------------------------------------------------------------------
+		BUT : Ajoute une ligne au debug si celui-ci est activé
+
+		IN  : $line	-> La ligne à ajouter
+	#>
+	[void] debugLog([string]$line)
+	{
+		if($null -ne $this.logHistory)
+		{
+			$funcName = ""
+
+			ForEach($call in (Get-PSCallStack))
+			{
+				if(@("callAPI", "debugLog") -notcontains $call.FunctionName)
+				{
+					$funcName = $call.FunctionName
+					break
+				}
+			}
+			
+			$this.logHistory.addDebug(("{0}::{1}(): {2}" -f $this.GetType().Name, $funcName, $line))
 		}
 	}
     

--- a/powershell/include/REST/RESTAPI.inc.ps1
+++ b/powershell/include/REST/RESTAPI.inc.ps1
@@ -68,6 +68,8 @@ class RESTAPI: APIUtils
 	{
 		$this.lastBody = $body
 
+		$this.debugLog(("Invoke-RestMethod: $($method) $($uri) `nBody:`n{0}" -f (ConvertTo-Json -InputObject $body -Depth 20)))
+
 		# Si la requête est de la lecture
 		if($method.ToLower() -eq "get")
 		{
@@ -89,6 +91,7 @@ class RESTAPI: APIUtils
 		$nbCurlAttempts = 2
 		for($currentAttemptNo=1; $currentAttemptNo -le $nbCurlAttempts; $currentAttemptNo++)
 		{
+			$this.debugLog("Invoke-RestMethod attempt: $($currentAttemptNo)")
 			try
 			{
 				if($null -ne $body)

--- a/powershell/include/REST/RESTAPICurl.inc.ps1
+++ b/powershell/include/REST/RESTAPICurl.inc.ps1
@@ -161,10 +161,13 @@ class RESTAPICurl: RESTAPI
 
 			$curlArgs += ' --data "@{0}"' -f $tmpFile
 		}
+		
 
 		# Ajout des arguments 
 		# Explication sur le @'...'@ ici : https://stackoverflow.com/questions/18116186/escaping-quotes-and-double-quotes
 		$this.curl.StartInfo.Arguments = "{0} {1} `"{2}`"" -f ( $this.getCurlHeaders() ), $curlArgs, ($uri -replace " ","%20")
+
+		$this.debugLog(("{0}`nBody:`n{1}" -f $this.curl.StartInfo.Arguments, $body))
 
 		$result = $null
 
@@ -172,6 +175,7 @@ class RESTAPICurl: RESTAPI
 		$nbCurlAttempts = 2
 		for($currentAttemptNo=1; $currentAttemptNo -le $nbCurlAttempts; $currentAttemptNo++)
 		{
+			$this.debugLog("CURL attempt: $($currentAttemptNo)")
 			$this.curl.Start() | Out-Null
 
 			$output = $this.curl.StandardOutput.ReadToEnd()

--- a/powershell/include/REST/XaaS/S3/ScalityAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/S3/ScalityAPI.inc.ps1
@@ -121,6 +121,7 @@ class ScalityAPI: APIUtils
 	#>
     [PSObject] addBucket([string]$bucketName)
     {
+        $this.debugLog("New-S3Bucket -bucketName $($bucketName)")
         # Documentation: https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/New-S3Bucket.html
         return New-S3Bucket -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                             -BucketName $bucketName 
@@ -137,6 +138,7 @@ class ScalityAPI: APIUtils
 	#>
     [PSObject] getBucket([string]$bucketName)
     {
+        $this.debugLog("Get-S3Bucket -bucketName $($bucketName)")
         # Documentation: https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Get-S3Bucket.html
         return Get-S3Bucket -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                              -BucketName $bucketName 
@@ -151,6 +153,7 @@ class ScalityAPI: APIUtils
 	#>
     [PSObject] getBucketList()
     {
+        $this.debugLog("Get-S3Bucket (all)")
         # Documentation: https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Get-S3Bucket.html
         return Get-S3Bucket -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials 
     }
@@ -181,6 +184,7 @@ class ScalityAPI: APIUtils
         # On n'efface que si le bucket existe, bien évidemment.
         if($this.bucketExists($bucketName))
         {
+            $this.debugLog("Remove-S3Bucket -bucketName $($bucketName)")
             # Documentation: https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Remove-S3Bucket.html
             Remove-S3Bucket -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                             -BucketName $bucketName -DeleteBucketContent:$false -Confirm:$false
@@ -214,6 +218,7 @@ class ScalityAPI: APIUtils
             $status = "Suspended"
         }
 
+        $this.debugLog("Write-S3BucketVersioning -bucketName $($bucketName) -VersioningConfig_Status $($status)")
         # Documentation: https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Write-S3BucketVersioning.html
         Write-S3BucketVersioning -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                                     -BucketName $bucketName -VersioningConfig_Status $status
@@ -231,6 +236,7 @@ class ScalityAPI: APIUtils
 	#>
     [bool] bucketVersioningEnabled([string]$bucketName)
     {
+        $this.debugLog("Get-S3BucketVersioning -bucketName $($bucketName)")
         # Documentation: https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Get-S3BucketVersioning.html
         $currentStatus = (Get-S3BucketVersioning -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials -BucketName $bucketName).status
 
@@ -248,6 +254,7 @@ class ScalityAPI: APIUtils
 	#>
     [Array] getBucketPolicyList([string]$bucketName)
     {
+        $this.debugLog("Get-IAMPolicyList (all)")
         # Récupération de la liste des policies et filtre si le bucket est contenu dedans
         return Get-IAMPolicyList -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials | Where-Object { $this.getPolicyBucketList($_.PolicyName) -contains $bucketName }
     }
@@ -317,6 +324,7 @@ class ScalityAPI: APIUtils
             return $user
         }
 
+        $this.debugLog("New-IAMUser -username $($username)")
         return New-IAMUser -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                             -UserName $username
     }
@@ -332,6 +340,7 @@ class ScalityAPI: APIUtils
 	#>
     [PSObject] getUser([string]$username)
     {
+        $this.debugLog("Get-IAMUserList")
         return Get-IAMUserList -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials | Where-Object {$_.Username -eq $username}
     }
 
@@ -344,6 +353,7 @@ class ScalityAPI: APIUtils
 	#>
     [void] deleteUser([string]$username)
     {
+        $this.debugLog("Remove-IAMUser -UserName $($username)")
         Remove-IAMUser -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                          -UserName $username -Confirm:$false
     }
@@ -361,9 +371,11 @@ class ScalityAPI: APIUtils
     {
         $userList = @()
 
+        $this.debugLog("Get-IAMUserList")
         # Parcours de tous les utilisateurs du système
         Get-IAMUserList -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials | ForEach-Object {
 
+            $this.debugLog("Get-IAMAttachedUserPolicyList -UserName $($_.UserName)")
             # Recherche si l'utilisateur courant est attaché à la policy recherchée 
             # https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Get-IAMAttachedUserPolicyList.html
             if($null -ne (Get-IAMAttachedUserPolicyList -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
@@ -412,6 +424,8 @@ class ScalityAPI: APIUtils
     {
         # On commence par supprimer les clefs existantes afin de toujours en avoir qu'une seule de valide
         $this.deleteUserAccessKeys($username)
+
+        $this.debugLog("New-IAMAccessKey -UserName $($username)")
         # Génération de nouvelles clefs
         return New-IAMAccessKey -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                                 -UserName $username
@@ -429,6 +443,7 @@ class ScalityAPI: APIUtils
 	#>
     [Array] getUserAccessKeys([string]$username)
     {
+        $this.debugLog("Get-IAMAccessKey -UserName $($username)")
         return Get-IAMAccessKey -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                                 -UserName $username
     }
@@ -442,8 +457,11 @@ class ScalityAPI: APIUtils
 	#>
     [void] deleteUserAccessKeys([string] $username)
     {
+        $this.debugLog("Get-IAMAccessKey -UserName $($username)")
         Get-IAMAccessKey -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials -UserName $username | ForEach-Object {
-             Remove-IAMAccessKey -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
+
+            $this.debugLog("Remove-IAMAccessKey -UserName $($username) -AccessKeyId $($_.AccessKeyId)")
+            Remove-IAMAccessKey -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                                 -UserName $username -AccessKeyId $_.AccessKeyId -Confirm:$false
         }
     }
@@ -467,6 +485,7 @@ class ScalityAPI: APIUtils
 	#>
     hidden [void] cleanOldPolicyVersions([string]$policyArn)
     {
+        $this.debugLog("Get-IAMPolicyVersionList -PolicyArn $($policyArn)")
         # Recherche de la liste des versions de la policy
         Get-IAMPolicyVersionList -endpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                                  -PolicyArn $policyArn | ForEach-Object {
@@ -474,6 +493,7 @@ class ScalityAPI: APIUtils
             # Si ce n'est pas la version active, on la supprime
             if(!($_.IsDefaultVersion))
             {
+                $this.debugLog("Remove-IAMPolicyVersion -PolicyArn $($policyArn) -VersionId $($_.VersionId)")
                 Remove-IAMPolicyVersion -endpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                                         -PolicyArn $policyArn -VersionId $_.VersionId -Confirm:$false
             }
@@ -509,6 +529,7 @@ class ScalityAPI: APIUtils
 	#>
     hidden [string] getPolicyArn([string]$policyName)
     {
+        $this.debugLog("Get-IAMPolicies")
         $pol = Get-IAMPolicies -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials | Where-Object { $_.PolicyName -eq $policyName}
 
         if($null -eq $pol)
@@ -544,9 +565,11 @@ class ScalityAPI: APIUtils
 
         $body = $this.createObjectFromJSON($jsonFile, $replace)
 
+        $policyDocument = (ConvertTo-Json -InputObject $body -Depth 20)
+        $this.debugLog("New-IAMPolicy -PolicyName $($policyName) -policyDocument $($policyDocument)")
         # Ajout de la nouvelle policy
         $pol = New-IAMPolicy -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
-                            -PolicyName $policyName -PolicyDocument (ConvertTo-Json -InputObject $body -Depth 20)
+                            -PolicyName $policyName -PolicyDocument $policyDocument
 
         return $pol
     }
@@ -570,6 +593,7 @@ class ScalityAPI: APIUtils
             return $null
         }
 
+        $this.debugLog("Get-IAMPolicy -PolicyArn $($polArn)")
         # Retour des informations complètes en cherchant avec l'Arn
         return Get-IAMPolicy -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                             -PolicyArn $polArn
@@ -598,6 +622,7 @@ class ScalityAPI: APIUtils
         # effacer celle-ci: https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeletePolicy.html
         $this.cleanOldPolicyVersions($polArn)
 
+        $this.debugLog("Remove-IAMPolicy -PolicyArn $($polArn)")
         Remove-IAMPolicy -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                             -PolicyArn $polArn -Confirm:$false
     }
@@ -660,10 +685,13 @@ class ScalityAPI: APIUtils
             active passera en 'inactive' et on aura l'historique de la version précédente #>
             $this.cleanOldPolicyVersions($policy.Arn)
 
+            $policyDocument = (ConvertTo-Json -InputObject $polContent -Depth 20)
+
+            $this.debugLog("New-IAMPolicyVersion -PolicyArn $($policy.Arn) -SetAsDefault true -policyDocument $($policyDocument)")
             # Ajout de la nouvelle version de policy
-            $dummy = New-IAMPolicyVersion -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
-                                    -PolicyArn $policy.Arn -PolicyDocument (ConvertTo-Json -InputObject $polContent -Depth 20) `
-                                    -SetAsDefault $true
+            New-IAMPolicyVersion -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
+                                    -PolicyArn $policy.Arn -PolicyDocument $policyDocument `
+                                    -SetAsDefault $true | Out-Null
             
             $policy = $this.getPolicy($policyName)
         }
@@ -746,10 +774,13 @@ class ScalityAPI: APIUtils
             active passera en 'inactive' et on aura l'historique de la version précédente #>
             $this.cleanOldPolicyVersions($policy.Arn)
 
+            $policyDocument = (ConvertTo-Json -InputObject $polContent -Depth 20)
+
+            $this.debugLog("New-IAMPolicyVersion -PolicyArn $($policy.Arn) -SetAsDefault true -policyDocument $($policyDocument)")
             # Ajout de la nouvelle version de policy
-            $dummy = New-IAMPolicyVersion -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
-                                    -PolicyArn $policy.Arn -PolicyDocument (ConvertTo-Json -InputObject $polContent -Depth 20) `
-                                    -SetAsDefault $true
+            New-IAMPolicyVersion -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
+                                    -PolicyArn $policy.Arn -PolicyDocument $policyDocument `
+                                    -SetAsDefault $true | Out-Null
             
             $policy = $this.getPolicy($policyName)
         }
@@ -814,6 +845,8 @@ class ScalityAPI: APIUtils
             # Récupération des informations de la policy
             $policy = $this.getPolicy($policyName)
 
+            $this.debugLog("Register-IAMUserPolicy -PolicyArn $($policy.Arn) -UserName $($username)")
+
             # Documentation : https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Register-IAMUserPolicy.html
             Register-IAMUserPolicy -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                                     -UserName $username -PolicyArn $policy.Arn 
@@ -835,6 +868,8 @@ class ScalityAPI: APIUtils
         {
             # Récupération des informations de la policy
             $policy = $this.getPolicy($policyName)
+
+            $this.debugLog("Unregister-IAMUserPolicy -PolicyArn $($policy.Arn) -UserName $($username)")
 
             # Documentation : https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Unregister-IAMUserPolicy.html
             Unregister-IAMUserPolicy -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
@@ -862,6 +897,7 @@ class ScalityAPI: APIUtils
 	#>
     [PSObject] getBucketObjectList([string]$bucketName)
     {
+        $this.debugLog("Get-S3Object -bucketName $($bucketName)")
         # https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Get-S3Object.html
         return Get-S3Object -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                              -BucketName $bucketName

--- a/powershell/xaas-backup-endpoint.ps1
+++ b/powershell/xaas-backup-endpoint.ps1
@@ -141,6 +141,13 @@ try
             $vsphereApi = [vSphereAPI]::new($configXaaSBackup.getConfigValue($targetEnv, "vSphere", "server"), 
             $configXaaSBackup.getConfigValue($targetEnv, "vSphere", "user"), 
             $configXaaSBackup.getConfigValue($targetEnv, "vSphere", "password"))
+
+            # Si on doit activer le Debug,
+            if(Test-Path (Join-Path $PSScriptRoot "$($MyInvocation.MyCommand.Name).debug"))
+            {
+                # Activation du debug
+                $vsphereApi.activateDebug($logHistory)    
+            }
         }
 
         { ($_ -eq $ACTION_GET_BACKUP_LIST) -or ($_ -eq $ACTION_RESTORE_BACKUP) -or ($_ -eq $ACTION_GET_RESTORE_STATUS)} {
@@ -148,6 +155,13 @@ try
             $nbu = [NetBackupAPI]::new($configXaaSBackup.getConfigValue($targetEnv, "backup", "server"), 
             $configXaaSBackup.getConfigValue($targetEnv, "backup", "user"), 
             $configXaaSBackup.getConfigValue($targetEnv, "backup", "password"))   
+
+            # Si on doit activer le Debug,
+            if(Test-Path (Join-Path $PSScriptRoot "$($MyInvocation.MyCommand.Name).debug"))
+            {
+                # Activation du debug
+                $nbu.activateDebug($logHistory)    
+            }
         }
 
         $ACTION_VM_HAS_RUNNING_SNAPSHOT {
@@ -156,6 +170,13 @@ try
                                 $targetTenant, 
                                 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "user"), 
                                 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "password"))
+        
+            # Si on doit activer le Debug,
+            if(Test-Path (Join-Path $PSScriptRoot "$($MyInvocation.MyCommand.Name).debug"))
+            {
+                # Activation du debug
+                $vra.activateDebug($logHistory)    
+            }
         }
     }
 

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -509,6 +509,14 @@ try
                                 $configNAS.getConfigValue($targetEnv, "user"), `
                                 $configNAS.getConfigValue($targetEnv, "password"))
 
+    # Si on doit activer le Debug,
+    if(Test-Path (Join-Path $PSScriptRoot "$($MyInvocation.MyCommand.Name).debug"))
+    {
+        # Activation du debug
+        $netapp.activateDebug($logHistory)    
+        $vra.activateDebug($logHistory)
+    }
+
     # Objet pour pouvoir envoyer des mails de notification
 	$valToReplace = @{
 		targetEnv = $targetEnv

--- a/powershell/xaas-s3-endpoint.ps1
+++ b/powershell/xaas-s3-endpoint.ps1
@@ -266,6 +266,13 @@ try
                                  $configXaaSS3.getConfigValue($targetEnv, $targetTenant, "webConsolePassword"),
                                  $configXaaSS3.getConfigValue($targetEnv, "isScality"))
 
+    # Si on doit activer le Debug,
+    if(Test-Path (Join-Path $PSScriptRoot "$($MyInvocation.MyCommand.Name).debug"))
+    {
+        # Activation du debug
+        $scality.activateDebug($logHistory)    
+    }
+    
 
     # Objet pour pouvoir envoyer des mails de notification
 	$valToReplace = @{


### PR DESCRIPTION
Ajout de logging de style "debug" pour les appels REST pour tous les scripts de "endpoint"
Celui-ci est activable en créant un fichier portant le nom du script et en ajoutant `.debug` à la fin.

# Tâches après merge
- [ ] Mettre à jour la branche `xaas-k8s` avec les nouveaux fichiers
- [ ] Ajouter le nécessaire pour activer le debug aussi pour K8s
- [ ] Mettre à jour Confluence pour ajouter une documentation pour le debug dans les scripts de Endpoint
