### PR TITLE
XaaS S3 - Fix Bucket creation

### DIFF
--- a/powershell/include/REST/XaaS/S3/ScalityAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/S3/ScalityAPI.inc.ps1
@@ -400,7 +400,11 @@ class ScalityAPI: APIUtils
 	#>
     hidden [bool] userIsInPolicy([string]$username, [string]$policyName)
     {
-        return  ($this.getPolicyUserList($policyName) | Where-Object {$_.UserName -eq $username} ).Count -gt 0
+        $this.debugLog("Get-IAMAttachedUserPolicyList -UserName $($username)")
+        # Recherche si l'utilisateur courant est attaché à la policy recherchée 
+        # https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Get-IAMAttachedUserPolicyList.html
+        return ($null -ne (Get-IAMAttachedUserPolicyList -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
+                          -UserName $username | Where-Object { $_.PolicyName -eq $policyName}  ))
     }
 
     <#


### PR DESCRIPTION
Actuellement, les branques qui développent Scality fournissent une liste d'utilisateurs présents dans le système mais dès qu'on veut récupérer des infos dessus (liste des policies par exemple), bah erreeeeeur! en fait, il s'avère que l'info ne peut pas être trouvée... sur la console Web, on peut reproduire le problème et on voit bien une erreur `404 Not Found` lorsqu'il essaie d'accéder à l'URL où devraient être les détails pour un utilisateur donné 🙄 

Bref, pour ce qui est de la création des buckets, il a été possible de faire en sorte de ne pas passer par le bout de code qui pose problème, et pire, ça améliore même les performances !!
Par contre, il reste encore que les actions day2 suivantes ne pourront pas fonctionner correctement:
- delete Bucket
- regen Keys
- get User list