### PR TITLE
New NAS names, bugfixes

### DIFF
--- a/powershell/include/XaaS/NAS/NameGeneratorNAS.inc.ps1
+++ b/powershell/include/XaaS/NAS/NameGeneratorNAS.inc.ps1
@@ -69,15 +69,15 @@ class NameGeneratorNAS: NameGeneratorBase
 		-------------------------------------------------------------------------------------
 		BUT : Constructeur de classe pour un volume de type Applicatif
 
-      IN  : $faculty          -> Nom de la faculté
+      IN  : $svcId            -> ID du service ITServices
       IN  : $desiredVolName   -> nom de volume désiré
 	#>
-   [void] setApplicativeDetails([string]$faculty, [string]$desiredVolName)
+   [void] setApplicativeDetails([string]$svcId, [string]$desiredVolName)
    {
       $this.type = [NASStorageType]::Applicative
 
       $this.details = @{
-         faculty = $faculty.toLower()
+         svcId = $svcId.toLower()
          desiredVolName = $desiredVolName.toLower()
       }
    }
@@ -94,7 +94,7 @@ class NameGeneratorNAS: NameGeneratorBase
 	#>
    [string] getVolName([int]$volNumber, [bool]$isNFSVolume)
    {
-      $volName = ("{0}_{1}_{2}_{3}_files" -f $this.details.faculty, $this.details.unitName, $this.details.unitId, $volNumber)
+      $volName = ("u{0}_{1}_{2}_{3}_files" -f $this.details.unitId, $this.details.faculty, $this.details.unitName, $volNumber)
 
       if($isNFSVolume)
       {
@@ -113,7 +113,7 @@ class NameGeneratorNAS: NameGeneratorBase
 	#>
    [string] getVolName()
    {
-      return ("{0}_{1}_app" -f $this.details.faculty, $this.details.desiredVolName)
+      return ("{0}_{1}_app" -f $this.details.svcId, $this.details.desiredVolName)
    }
 
 
@@ -176,7 +176,7 @@ class NameGeneratorNAS: NameGeneratorBase
 	#>
    [string] getCollaborativeVolDetailedRegex([bool]$isNFS)
    {
-      $regex = ("{0}_[a-z]+_{1}_[0-9]_files" -f $this.details.faculty, $this.details.unitId)
+      $regex = ("u{0}_{1}_[a-z]+_[0-9]_files" -f $this.details.unitId, $this.details.faculty)
 
       if($isNFS)
       {

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -4,7 +4,7 @@ USAGES:
     xaas-nas-endpoint.ps1 -targetEnv prod|test|dev -targetTenant epfl|research -action create -volType col -sizeGB <sizeGB> -bgId <bgId> -access nfs3 -svm <svm> -IPsRoot <IPsRoot> -IPsRO <IPsRO> -IPsRW <IPsRW> -snapPercent <snapPercent> -snapPolicy <snapPolicy>
     xaas-nas-endpoint.ps1 -targetEnv prod|test|dev -targetTenant itservices|research -action create -volType app -sizeGB <sizeGB> -bgId <bgId> -access cifs|nfs3 -IPsRoot <IPsRoot> -IPsRO <IPsRO> -IPsRW <IPsRW> -volName <volName>
     xaas-nas-endpoint.ps1 -targetEnv prod|test|dev -targetTenant itservices|epfl|research -action delete -volName <volName>
-    xaas-nas-endpoint.ps1 -targetEnv prod|test|dev -targetTenant itservices|research -action appVolExists -volName <volName>
+    xaas-nas-endpoint.ps1 -targetEnv prod|test|dev -targetTenant itservices|research -action appVolExists -volName <volName> -bgId <bgId>
     xaas-nas-endpoint.ps1 -targetEnv prod|test|dev -targetTenant epfl|research -action canHaveNewVol -bgId <bgId> -access cifs|nfs3
     xaas-nas-endpoint.ps1 -targetEnv prod|test|dev -targetTenant itservices|epfl|research -action resize -sizeGB <sizeGB> -volName <volName>
     xaas-nas-endpoint.ps1 -targetEnv prod|test|dev -targetTenant itservices|epfl|research -action getVolSize [-volName <volName>]
@@ -561,7 +561,7 @@ try
                 # ---- Volume Applicatif
                 ([XaaSNASVolType]::app).ToString()
                 {
-                    $nameGeneratorNAS.setApplicativeDetails($global:APP_VOL_DEFAULT_FAC, $volName)
+                    $nameGeneratorNAS.setApplicativeDetails($bgId, $volName)
 
                     # Chargement des informations sur le mapping des facultés
                     $appSVMFile = ([IO.Path]::Combine($global:DATA_FOLDER, "xaas", "nas", "applicative-svm.json"))
@@ -921,7 +921,7 @@ try
             }
 
             # Si on veut savoir pour un volume applicatif, 
-            $nameGeneratorNAS.setApplicativeDetails($global:APP_VOL_DEFAULT_FAC, $volName, $bgId)
+            $nameGeneratorNAS.setApplicativeDetails($bgId, $volName)
                 
             # on regarde quel nom devrait avoir le volume applicatif
             $volName = $nameGeneratorNAS.getVolName()
@@ -945,7 +945,15 @@ try
             $logHistory.addLine( "Looking for next volume name..." )
             # Recheche du prochain nom de volume
             $volName = getNextColVolName -netapp $netapp -nameGeneratorNAS $nameGeneratorNAS -access $access
-            $logHistory.addLine( ("Next volume name is '{0}'" ) -f $volName)
+            if($null -eq $volName)
+            {
+                $logHistory.addLine(("Maximum number of volume reached for BG {0} ({1})" -f $bg.name, $bgId))
+            }
+            else
+            {
+                $logHistory.addLine( ("Next volume name is '{0}'" ) -f $volName)
+            }
+            
             $output.results += @{
                 canHaveNewVol = ($null -ne $volName)
             }


### PR DESCRIPTION
Gestion des nouveaux noms pour le NAS.
**EPFL** On passe de `<fac>_<unitName>_[1-9]_coll` ▶️  `u<unitId>_<fac>_<unitName>_[1-9]_coll`
**ITServices** `si_<desiredFSName>_app` ▶️ `<svcId>_<desiredFSName>_app`

- Correction d'un bug qui faisait qu'on passait un paramètre de trop à une fonction.