### PR TITLE
Bugfix entitled items legacy

### DIFF
--- a/powershell/include/NotificationMail.inc.ps1
+++ b/powershell/include/NotificationMail.inc.ps1
@@ -147,7 +147,7 @@ class NotificationMail
         Get-Content -Path $this.getPathToTemplateFile("_footer") | Out-File $tmpMailFile -Encoding default -Append
 
         # 4. Ajout de la quote de fin
-        $this.getRandomHTMLQuote() | Out-File $tmpMailFile -Encoding default -Append
+        ("<br>{0}" -f $this.getRandomHTMLQuote()) | Out-File $tmpMailFile -Encoding default -Append
 
         $mailMessage = Get-Content $tmpMailFile -Encoding UTF8 | Out-String
         Remove-Item $tmpMailFile -Force

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -1486,6 +1486,7 @@ class vRAAPI: RESTAPICurl
 		return $result
 	}
 
+
 	<#
 		-------------------------------------------------------------------------------------
 		BUT : Renvoie la liste des Items qui sont au catalogue pour un service.
@@ -1498,6 +1499,27 @@ class vRAAPI: RESTAPICurl
 	[Array] getServiceCatalogItemList([PSObject] $service)
 	{
 		return $this.getCatalogItemListQuery(("`$filter=service/id eq '{0}' and status eq 'PUBLISHED'" -f $service.id))
+	}
+
+
+	<#
+		-------------------------------------------------------------------------------------
+		BUT : Renvoie les infos d'un item de catalogue donné par son nom
+			  
+		IN  : $name			-> Nom de l'élément de cataloguq que l'on désire
+
+		RET : Objet avec les détails de l'élément de catalogue
+				$null si pas trouvé
+	#>
+	[PSObject] getCatalogItem([string]$name)
+	{
+		$results = $this.getCatalogItemListQuery(("`$filter=name eq '{0}' and status eq 'PUBLISHED'" -f $name))
+
+		if($results.count -eq 0)
+		{
+			return $null
+		}
+		return $results[0]
 	}
 
 

--- a/powershell/resources/README.md
+++ b/powershell/resources/README.md
@@ -20,3 +20,8 @@ Contient la liste des services IT pour lesquels il faut créer un Business Group
 
 ### mail-quotes.json
 Juste pour le fun :rofl: pour ajouter des quotes aléatoires à la fin des mails envoyés aux admins.
+
+### mandatory-entitled-items.json
+Afin de pouvoir continuer à gérer les VM importées depuis MyVM sans pouvoir avoir la possibilité de demander une nouvelle VM de ce type, on doit ajouter des éléments du catalogue
+non pas dans le service "VM (Public)" mais directement dans les "Entitled items" qui sont dans chaque "Entitlement". 
+On liste donc ici ces éléments de catalogue à ajouter dans tous les cas, en définissant s'ils ont besoin d'avoir une approval policy ou pas.

--- a/powershell/resources/mail-templates/mandatory-catalog-items-not-found.html
+++ b/powershell/resources/mail-templates/mandatory-catalog-items-not-found.html
@@ -1,0 +1,5 @@
+Les éléments de catalogue à ajouter de manière obligatoire suivants n'ont pas été trouvés:
+<br>
+<ul>
+    <li>{{itemList}}</li>
+</ul>

--- a/powershell/resources/mandatory-entitled-items.json
+++ b/powershell/resources/mandatory-entitled-items.json
@@ -1,4 +1,10 @@
 [
-    "Legacy_Linux_MyVM",
-    "Legacy_Windows_MyVM"
+    {
+        "name": "Legacy_Linux_MyVM",
+        "hasApproval": false
+    },
+    {
+        "name": "Legacy_Windows_MyVM",
+        "hasApproval": false
+    }
 ]

--- a/powershell/resources/mandatory-entitled-items.json
+++ b/powershell/resources/mandatory-entitled-items.json
@@ -1,0 +1,4 @@
+[
+    "Legacy_Linux_MyVM",
+    "Legacy_Windows_MyVM"
+]

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -607,19 +607,32 @@ function prepareAddMissingBGEntPublicServices
 
 		# Parcours et ajout
 		$mandatoryItems | ForEach-Object {
-			$catalogItem = $vra.getCatalogItem($_)
+			$catalogItem = $vra.getCatalogItem($_.name)
 
 			if($null -eq $catalogItem)
 			{
-				$logHistory.addWarningAndDisplay(("--> Catalog item '{0}' not found!" -f $_))
-				$notifications.mandatoryItemsNotFound += $_
+				$logHistory.addWarningAndDisplay(("--> Catalog item '{0}' not found!" -f $_.name))
+				$notifications.mandatoryItemsNotFound += $_.name
 			}
-			else
+			else # L'élément de catalogue existe
 			{
-				$logHistory.addLineAndDisplay(("--> Adding catalog item '{0}'..." -f $_))
-				$ent = $vra.prepareAddEntCatalogItem($ent, $catalogItem, $approvalPolicy)
+				$logHistory.addLineAndDisplay(("--> Adding catalog item '{0}'..." -f $_.name))
+
+				# Définition de la potentielle approval policy à mettre
+				if($_.hasApproval)
+				{
+					$itemApprovalPolicy = $approvalPolicy
+				}
+				else
+				{
+					$itemApprovalPolicy = $null
+				}
+				
+				$ent = $vra.prepareAddEntCatalogItem($ent, $catalogItem, $itemApprovalPolicy)
 			}
-		}
+			
+		}# FIN BOUCLE de parcours des éléments de catalogue obligatoires
+
 	}# FIN SI il y a des éléments de catalogue obligatoires à ajouter
 
 	# Parcours des services à ajouter à l'entitlement créé


### PR DESCRIPTION
Suite à la mise en production de "Release-19" ( #141 ), un petit effet de bord a été constaté pour les actions day-2 sur les VM Legacy (venant de MyVM). Plus aucune action Day-2 n'était disponible... 
Le problème provenait du fait que pour ces VM, on avait manuellement ajouté des "entitled items" dans l'entitlement des BG ayant ce type d'élément.
Le code mis en production dans "Release-19" gère maintenant la liste des "Entitled items" et donc un nettoyage a été fait automatiquement pour virer les items qui auraient dû rester... 
Cette PR est là pour corriger le problème et faire en sorte de pouvoir ajouter de manière automatique des items qui doivent être présent dans tous les BG (enfin, ils sont nécessaires uniquement dans les BG où il y a des VM "Legacy" mais ça ne mange pas de pain de les mettre partout). 