### PR TITLE
Add new level for AD group organization

### DIFF
--- a/powershell/include/NameGenerator.inc.ps1
+++ b/powershell/include/NameGenerator.inc.ps1
@@ -25,6 +25,15 @@
         ensuite de fonctions plus génériques
 
 #>
+
+# Types d'OU qui peut se trouver dans une OU de tenant.
+enum ADSubOUType
+{
+    Approval
+    Support
+    User
+}
+
 class NameGenerator: NameGeneratorBase
 {
     
@@ -1168,17 +1177,28 @@ class NameGenerator: NameGeneratorBase
         BUT : Renvoie le DN de l'OU Active Directory à utiliser pour mettre les groupes 
               de l'environnement et du tenant courant.
 
-        IN  : $onlyForTenant -> $true|$false pour dire si on veut l'OU pour un groupe
-                                    qui sera utilisé par tous les tenants et pas qu'un seul.  
+        IN  : $forCurrentTenantOnly -> $true|$false pour dire si on veut l'OU pour un groupe
+                                        qui sera utilisé pour le tenant courant OU pour tous les tenants
+        IN  : $finalOUType          -> (optionnel) Type de l'OU finale
 
 		RET : DN de l'OU
     #>
-    [string] getADGroupsOUDN([bool]$onlyForTenant)
+    [string] getADGroupsOUDN([bool]$forCurrentTenantOnly)
     {
-        
+        return $this.getADGroupsOUDN($forCurrentTenantOnly, $null)
+    }
+    [string] getADGroupsOUDN([bool]$forCurrentTenantOnly, [ADSubOUType]$finalOUType)
+    {
+        $subOU =""
+        # Si on doit ajouter le niveau final, 
+        if($null -ne $finalOUType)
+        {
+            $subOU = "OU={0}," -f $finalOUType.ToString().ToLower()
+        }
+
         $tenantOU = ""
         # Si le groupe que l'on veut créer dans l'OU doit être dispo pour le tenant courant uniquement, 
-        if($onlyForTenant)
+        if($forCurrentTenantOnly)
         {
             $tenantOU = "OU="
             switch($this.tenant)
@@ -1201,7 +1221,7 @@ class NameGenerator: NameGeneratorBase
         }
 
         # Retour du résultat 
-        return '{0}OU={1},OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch' -f $tenantOU, $envOU
+        return '{0}{1}OU={2},OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch' -f $subOU, $tenantOU, $envOU
     }
 
 

--- a/powershell/include/NameGenerator.inc.ps1
+++ b/powershell/include/NameGenerator.inc.ps1
@@ -100,106 +100,6 @@ class NameGenerator: NameGeneratorBase
         return $this.sanitizeName($facultyName).ToLower()
     }
     
-    <#
-        -------------------------------------------------------------------------------------
-        BUT : Renvoie l'expression régulière permettant de définir si un nom de groupe est 
-              un nom pour le rôle passé.
-
-        IN  : $role     -> Nom du rôle pour lequel on veut la RegEX
-                            "CSP_SUBTENANT_MANAGER"
-							"CSP_SUPPORT"
-							"CSP_CONSUMER_WITH_SHARED_ACCESS"
-                            "CSP_CONSUMER"
-
-        RET : L'expression régulières
-    #>
-    [string] getADGroupNameRegEx([string]$role)
-    {
-        
-        switch($this.tenant)
-        {
-            # Tenant EPFL
-            $global:VRA_TENANT__EPFL 
-            {
-                if($role -eq "CSP_SUBTENANT_MANAGER")
-                {
-                    # vra_<envShort>_adm_<tenantShort>
-                    return "^{0}{1}_adm_{2}$" -f [NameGenerator]::AD_GROUP_PREFIX, $this.getEnvShortName(), $this.getTenantShortName()
-                }
-                # Support
-                elseif($role -eq "CSP_SUPPORT")
-                {
-                    # vra_<envShort>_sup_<facultyName>
-                    return "^{0}{1}_sup_\d+$" -f [NameGenerator]::AD_GROUP_PREFIX, $this.getEnvShortName()
-                }
-                # Shared, Users
-                elseif($role -eq "CSP_CONSUMER_WITH_SHARED_ACCESS" -or `
-                        $role -eq "CSP_CONSUMER")
-                {
-                    # vra_<envShort>_<facultyID>_<unitID>
-                    return "^{0}{1}_\d+_\d+$" -f [NameGenerator]::AD_GROUP_PREFIX, $this.getEnvShortName()
-                }  
-                else
-                {
-                    Throw ("Incorrect role given ({0})" -f $role)
-                }
-            }
-
-            # Tenant ITServices
-            $global:VRA_TENANT__ITSERVICES
-            {
-                if($role -eq "CSP_SUBTENANT_MANAGER" -or `
-                    $role -eq "CSP_SUPPORT")
-                {
-                    # vra_<envShort>_adm_sup_<tenantShort>
-                    return "^{0}{1}_adm_sup_{2}$" -f [NameGenerator]::AD_GROUP_PREFIX, $this.getEnvShortName(), $this.getTenantShortName()
-                }
-                # Shared, Users
-                elseif($role -eq "CSP_CONSUMER_WITH_SHARED_ACCESS" -or `
-                        $role -eq "CSP_CONSUMER")
-                {
-                    # vra_<envShort>_<serviceShort>
-                    # On ajoute une exclusion à la fin pour être sûr de ne pas prendre aussi les éléments qui sont pour les 2 rôles ci-dessus
-                    return "^{0}{1}(?!_approval)_\w+(?<!_adm_sup_{2})$" -f [NameGenerator]::AD_GROUP_PREFIX, $this.getEnvShortName(), $this.getTenantShortName()
-                }  
-                else
-                {
-                    Throw ("Incorrect role given ({0})" -f $role)
-                }
-            }
-
-            # Tenant Research
-            $global:VRA_TENANT__RESEARCH
-            {
-                if($role -eq "CSP_SUBTENANT_MANAGER" -or `
-                    $role -eq "CSP_SUPPORT")
-                {
-                    # vra_<envShort>_adm_sup_<tenantShort>
-                    return "^{0}{1}_adm_sup_{2}$" -f [NameGenerator]::AD_GROUP_PREFIX, $this.getEnvShortName(), $this.getTenantShortName()
-                }
-                # Shared, Users
-                elseif($role -eq "CSP_CONSUMER_WITH_SHARED_ACCESS" -or `
-                        $role -eq "CSP_CONSUMER")
-                {
-                    # vra_<envShort>_<projectId>
-                    # On ajoute une exclusion à la fin pour être sûr de ne pas prendre aussi les éléments qui sont pour les 2 rôles ci-dessus
-                    return "^{0}{1}(?!_approval)_[0-9]+(?<!_adm_sup_{2})$" -f [NameGenerator]::AD_GROUP_PREFIX, $this.getEnvShortName(), $this.getTenantShortName()
-                }  
-                else
-                {
-                    Throw ("Incorrect role given ({0})" -f $role)
-                }
-            }
-
-            # Tenant pas géré
-            default
-            {
-                Throw ("Unsupported Tenant ({0})" -f $this.tenant)
-            }
-        }
-        return $null
-    }
-
 
     <#
         -------------------------------------------------------------------------------------
@@ -1177,28 +1077,16 @@ class NameGenerator: NameGeneratorBase
         BUT : Renvoie le DN de l'OU Active Directory à utiliser pour mettre les groupes 
               de l'environnement et du tenant courant.
 
-        IN  : $forCurrentTenantOnly -> $true|$false pour dire si on veut l'OU pour un groupe
+        IN  : $onlyForTenant -> $true|$false pour dire si on veut l'OU pour un groupe
                                         qui sera utilisé pour le tenant courant OU pour tous les tenants
-        IN  : $finalOUType          -> (optionnel) Type de l'OU finale
 
 		RET : DN de l'OU
     #>
-    [string] getADGroupsOUDN([bool]$forCurrentTenantOnly)
+    [string] getADGroupsOUDN([bool]$onlyForTenant)
     {
-        return $this.getADGroupsOUDN($forCurrentTenantOnly, $null)
-    }
-    [string] getADGroupsOUDN([bool]$forCurrentTenantOnly, [ADSubOUType]$finalOUType)
-    {
-        $subOU =""
-        # Si on doit ajouter le niveau final, 
-        if($null -ne $finalOUType)
-        {
-            $subOU = "OU={0}," -f $finalOUType.ToString().ToLower()
-        }
-
         $tenantOU = ""
         # Si le groupe que l'on veut créer dans l'OU doit être dispo pour le tenant courant uniquement, 
-        if($forCurrentTenantOnly)
+        if($onlyForTenant)
         {
             $tenantOU = "OU="
             switch($this.tenant)
@@ -1221,7 +1109,32 @@ class NameGenerator: NameGeneratorBase
         }
 
         # Retour du résultat 
-        return '{0}{1}OU={2},OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch' -f $subOU, $tenantOU, $envOU
+        return '{0}OU={1},OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch' -f $tenantOU, $envOU
+    }
+
+
+    <#
+        -------------------------------------------------------------------------------------
+        BUT : Renvoie le DN de l'OU Active Directory à utiliser pour mettre les groupes d'un 
+                type donnée dans l'environnement et le tenant courant.
+
+        IN  : $finalOUType          -> (optionnel) Type de l'OU finale
+
+		RET : DN de l'OU
+    #>
+    [string] getADGroupsOUDN([bool]$onlyForTenant, [ADSubOUType]$finalOUType)
+    {
+        $result = $this.getADGroupsOUDN($onlyForTenant)
+
+        # Si on veut la chose avec le tenant
+        if($onlyForTenant)
+        {
+            # Dans ce cas-là on peut ajouter la "sous-OU". Sinon, on ne la met pas
+            $result = 'OU={0},{1}' -f  $finalOUType.ToString().ToLower(), $result
+        }
+
+        return $result
+        
     }
 
 

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -1490,7 +1490,6 @@ try
 	# Parcours des groupes AD qui sont dans l'OU de l'environnement donné. On ne prend que les groupes qui sont utilisés pour 
 	# donner des droits d'accès aux unités. Afin de faire ceci, on fait un filtre avec une expression régulière
 	Get-ADGroup  -Filter ("Name -like '*'") -SearchBase $nameGenerator.getADGroupsOUDN($true, [ADSubOUType]::User) -Properties Description | 
-	Where-Object {$_.Name -match $nameGenerator.getADGroupNameRegEx("CSP_CONSUMER")} | 
 	ForEach-Object {
 
 		# Si le groupe n'est pas dans ceux créés à partir de la source de données, c'est que l'élément n'existe plus. On supprime donc le groupe AD pour que 

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -803,7 +803,7 @@ try
 
 					# Création des groupes + gestion des groupes prérequis 
 					if((createADGroupWithContent -groupName $approveGroupInfos.name -groupDesc $approveGroupDescAD -groupMemberGroup $approveGroupNameGroups `
-						-OU $nameGenerator.getADGroupsOUDN($approveGroupInfos.onlyForTenant) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
+						-OU $nameGenerator.getADGroupsOUDN($approveGroupInfos.onlyForTenant, [ADSubOUType]::Approval) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
 					{
 						if($notifications.missingEPFLADGroups -notcontains $approveGroupNameGroups)
 						{
@@ -849,7 +849,7 @@ try
 
 
 				if((createADGroupWithContent -groupName $supportGroupNameAD -groupDesc $supportGroupDescAD -groupMemberGroup $supportGroupNameGroups `
-					-OU $nameGenerator.getADGroupsOUDN($true) -simulation $SIMULATION_MODE -updateExistingContent $false) -eq $false)
+					-OU $nameGenerator.getADGroupsOUDN($true, [ADSubOUType]::Support) -simulation $SIMULATION_MODE -updateExistingContent $false) -eq $false)
 				{
 					# Enregistrement du nom du groupe qui pose problème et passage à la faculté suivante car on ne peut pas créer celle-ci
 					$notifications.missingEPFLADGroups += $supportGroupNameGroups
@@ -974,7 +974,7 @@ try
 								if(-not $SIMULATION_MODE)
 								{
 									# Création du groupe
-									New-ADGroup -Name $adGroupName -Description $adGroupDesc -GroupScope DomainLocal -Path $nameGenerator.getADGroupsOUDN($true)
+									New-ADGroup -Name $adGroupName -Description $adGroupDesc -GroupScope DomainLocal -Path $nameGenerator.getADGroupsOUDN($true, [ADSubOUType]::User)
 								}
 
 								$counters.inc('ADGroupsCreated')
@@ -1198,7 +1198,7 @@ try
 
 						# Création des groupes + gestion des groupes prérequis 
 						if((createADGroupWithContent -groupName $approveGroupInfos.name -groupDesc $approveGroupDescAD -groupMemberGroup $approveGroupNameGroups `
-							-OU $nameGenerator.getADGroupsOUDN($approveGroupInfos.onlyForTenant) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
+							-OU $nameGenerator.getADGroupsOUDN($approveGroupInfos.onlyForTenant, [ADSubOUType]::Approval) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
 						{
 							# Enregistrement du nom du groupe qui pose problème et on note de passer au service suivant car on ne peut pas créer celui-ci
 							if($notifications.missingITSADGroups -notcontains $approveGroupNameGroups)
@@ -1260,7 +1260,7 @@ try
 
 					# Création des groupes + gestion des groupes prérequis 
 					if((createADGroupWithContent -groupName $userSharedGroupNameAD -groupDesc $userSharedGroupDescAD -groupMemberGroup $userSharedGroupNameGroupsAD `
-						-OU $nameGenerator.getADGroupsOUDN($true) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
+						-OU $nameGenerator.getADGroupsOUDN($true, [ADSubOUType]::User) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
 					{
 						# Enregistrement du nom du groupe qui pose problème et passage au service suivant car on ne peut pas créer celui-ci
 						if($notifications.missingADGroups -notcontains $userSharedGroupNameGroupsAD)
@@ -1382,7 +1382,7 @@ try
 					
 					# Création des groupes + gestion des groupes prérequis 
 					if((createADGroupWithContent -groupName $approveGroupInfos.name -groupDesc $approveGroupDescAD -groupMemberGroup $approveGroupNameGroupsAD `
-						-OU $nameGenerator.getADGroupsOUDN($approveGroupInfos.onlyForTenant) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
+						-OU $nameGenerator.getADGroupsOUDN($approveGroupInfos.onlyForTenant, [ADSubOUType]::Approval) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
 					{
 						# Enregistrement du nom du groupe qui pose problème et on note de passer au service suivant car on ne peut pas créer celui-ci
 						if($notifications.missingADGroups -notcontains $approveGroupNameGroupsAD)
@@ -1449,7 +1449,7 @@ try
 				$roleSharedGroupOk = $true
 				# Création des groupes + gestion des groupes prérequis 
 				if((createADGroupWithContent -groupName $userSharedGroupNameAD -groupDesc $userSharedGroupDescAD -groupMemberGroup $userSharedGroupNameGroupsAD `
-					 -OU $nameGenerator.getADGroupsOUDN($true) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
+					 -OU $nameGenerator.getADGroupsOUDN($true, [ADSubOUType]::User) -simulation $SIMULATION_MODE -updateExistingContent $true) -eq $false)
 				{
 					# Enregistrement du nom du groupe qui pose problème et passage au service suivant car on ne peut pas créer celui-ci
 					if($notifications.missingADGroups -notcontains $userSharedGroupNameGroupsAD)
@@ -1489,7 +1489,7 @@ try
 
 	# Parcours des groupes AD qui sont dans l'OU de l'environnement donné. On ne prend que les groupes qui sont utilisés pour 
 	# donner des droits d'accès aux unités. Afin de faire ceci, on fait un filtre avec une expression régulière
-	Get-ADGroup  -Filter ("Name -like '*'") -SearchBase $nameGenerator.getADGroupsOUDN($true) -Properties Description | 
+	Get-ADGroup  -Filter ("Name -like '*'") -SearchBase $nameGenerator.getADGroupsOUDN($true, [ADSubOUType]::User) -Properties Description | 
 	Where-Object {$_.Name -match $nameGenerator.getADGroupNameRegEx("CSP_CONSUMER")} | 
 	ForEach-Object {
 

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1469,14 +1469,10 @@ try
 
 
 	<# Recherche des groupes pour lesquels il faudra créer des OUs
-	 On prend tous les groupes de l'OU et on fait ensuite un filtre avec une expression régulière sur le nom. Au début, on prenait le début du nom du
-	 groupe pour filtrer mais d'autres groupes avec des noms débutant de la même manière ont été ajoutés donc le filtre par expression régulière
-	 a été nécessaire. #>
-	$adGroupNameRegex = $nameGenerator.getADGroupNameRegEx("CSP_CONSUMER")
+	 On prend tous les groupes de l'OU #>
 	
 	# La liste des propriétés pouvant être récupérées via -Properties
-	$adGroupList = Get-ADGroup -Filter ("Name -like '*'") -Server ad2.epfl.ch -SearchBase $nameGenerator.getADGroupsOUDN($true) -Properties Description,whenChanged | 
-	Where-Object {$_.Name -match $adGroupNameRegex} 
+	$adGroupList = Get-ADGroup -Filter ("Name -like '*'") -Server ad2.epfl.ch -SearchBase $nameGenerator.getADGroupsOUDN($true, [ADSubOUType]::User) -Properties Description,whenChanged 
 
 	# Création de l'objet pour récupérer les informations sur les approval policies à créer pour les demandes de nouveaux éléments
 	$newItems = [NewItems]::new("vra-new-items.json")

--- a/powershell/tests/include/ClassTester.inc.ps1
+++ b/powershell/tests/include/ClassTester.inc.ps1
@@ -155,7 +155,17 @@ class ClassTester
 
                 "String"
                 {
-                    $formattedParam = ("'{0}'" -f $param)
+                    # On regarde si c'est un type énuméré
+                    if([Regex]::matches($param, '\[.*?\]::.*?').Success)
+                    {
+                        # On peut le prendre tel quel et il sera interprété
+                        $formattedParam = $param
+                    }
+                    else # C'est un simple string
+                    {
+                        $formattedParam = ("'{0}'" -f $param)
+                    }
+                    
                 }
 
                 "Int32"

--- a/powershell/tests/test-namegenerator-epfl.json
+++ b/powershell/tests/test-namegenerator-epfl.json
@@ -23,28 +23,6 @@
         ]
     },
     {
-        "name": "getADGroupNameRegEx",
-        "tests": [
-            {
-                "params": ["CSP_SUBTENANT_MANAGER"],
-                "expected": "^vra_t_adm_epfl$"
-            },
-            {
-                "params": ["CSP_SUPPORT"],
-                "expected": "^vra_t_sup_\\d+$"
-            },
-            {
-                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS"],
-                "expected": "^vra_t_\\d+_\\d+$"
-            },
-            {
-                "params": ["CSP_CONSUMER"],
-                "expected": "^vra_t_\\d+_\\d+$"
-            }
-
-        ]
-    },
-    {
         "name": "getRoleADGroupName",
         "tests": [
             {
@@ -363,7 +341,7 @@
             }
         ]
     },
-
+    
     {
         "name": "getADGroupsOUDN",
         "tests":[
@@ -374,7 +352,12 @@
             {
                 "params": [false],
                 "expected": "OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
+            },
+            {
+                "params": ["[ADSubOUType]::Approval"],
+                "expected": "OU=approval,OU=EPFL,OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
             }
+            
         ]
     },
 

--- a/powershell/tests/test-namegenerator-epfl.json
+++ b/powershell/tests/test-namegenerator-epfl.json
@@ -354,8 +354,12 @@
                 "expected": "OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
             },
             {
-                "params": ["[ADSubOUType]::Approval"],
+                "params": [true, "[ADSubOUType]::Approval"],
                 "expected": "OU=approval,OU=EPFL,OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
+            },
+            {
+                "params": [false, "[ADSubOUType]::Approval"],
+                "expected": "OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
             }
             
         ]

--- a/powershell/tests/test-namegenerator-itservices.json
+++ b/powershell/tests/test-namegenerator-itservices.json
@@ -358,8 +358,12 @@
                 "expected": "OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
             },
             {
-                "params": ["[ADSubOUType]::Approval"],
+                "params": [true, "[ADSubOUType]::Approval"],
                 "expected": "OU=approval,OU=ITServices,OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
+            },
+            {
+                "params": [false, "[ADSubOUType]::Approval"],
+                "expected": "OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
             }
         ]
     },

--- a/powershell/tests/test-namegenerator-itservices.json
+++ b/powershell/tests/test-namegenerator-itservices.json
@@ -21,28 +21,6 @@
         ]
     },
     {
-        "name": "getADGroupNameRegEx",
-        "tests": [
-            {
-                "params": ["CSP_SUBTENANT_MANAGER"],
-                "expected": "^vra_t_adm_sup_its$"
-            },
-            {
-                "params": ["CSP_SUPPORT"],
-                "expected": "^vra_t_adm_sup_its$"
-            },
-            {
-                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS"],
-                "expected": "^vra_t(?!_approval)_\\w+(?\u003c!_adm_sup_its)$"
-            },
-            {
-                "params": ["CSP_CONSUMER"],
-                "expected": "^vra_t(?!_approval)_\\w+(?\u003c!_adm_sup_its)$"
-            }
-
-        ]
-    },
-    {
         "name": "getRoleADGroupName",
         "tests": [
             {
@@ -378,6 +356,10 @@
             {
                 "params": [false],
                 "expected": "OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
+            },
+            {
+                "params": ["[ADSubOUType]::Approval"],
+                "expected": "OU=approval,OU=ITServices,OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
             }
         ]
     },

--- a/powershell/tests/test-namegenerator-research.json
+++ b/powershell/tests/test-namegenerator-research.json
@@ -352,8 +352,12 @@
                 "expected": "OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
             },
             {
-                "params": ["[ADSubOUType]::Approval"],
+                "params": [true, "[ADSubOUType]::Approval"],
                 "expected": "OU=approval,OU=Research,OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
+            },
+            {
+                "params": [false, "[ADSubOUType]::Approval"],
+                "expected": "OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
             }
         ]
     },

--- a/powershell/tests/test-namegenerator-research.json
+++ b/powershell/tests/test-namegenerator-research.json
@@ -15,28 +15,6 @@
         ]
     },
     {
-        "name": "getADGroupNameRegEx",
-        "tests": [
-            {
-                "params": ["CSP_SUBTENANT_MANAGER"],
-                "expected": "^vra_t_adm_sup_rsrch$"
-            },
-            {
-                "params": ["CSP_SUPPORT"],
-                "expected": "^vra_t_adm_sup_rsrch$"
-            },
-            {
-                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS"],
-                "expected": "^vra_t(?!_approval)_[0-9]+(?\u003c!_adm_sup_rsrch)$"
-            },
-            {
-                "params": ["CSP_CONSUMER"],
-                "expected": "^vra_t(?!_approval)_[0-9]+(?\u003c!_adm_sup_rsrch)$"
-            }
-
-        ]
-    },
-    {
         "name": "getRoleADGroupName",
         "tests": [
             {
@@ -372,6 +350,10 @@
             {
                 "params": [false],
                 "expected": "OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
+            },
+            {
+                "params": ["[ADSubOUType]::Approval"],
+                "expected": "OU=approval,OU=Research,OU=Test,OU=XaaS,OU=DIT-Services Communs,DC=intranet,DC=epfl,DC=ch"
             }
         ]
     },

--- a/powershell/tests/test-namegenerator.ps1
+++ b/powershell/tests/test-namegenerator.ps1
@@ -34,16 +34,16 @@ $nameGenerator = [NameGenerator]::new('test', 'epfl')
 $jsonFile = ([IO.Path]::Combine("$PSScriptRoot", "test-namegenerator-epfl.json"))
 $classTester.runTests($jsonFile, $nameGenerator)
 
-# # ------------------------------------------
-# # Tests pour le tenant ITServices
+# ------------------------------------------
+# Tests pour le tenant ITServices
 
 $nameGenerator = [NameGenerator]::new('test', 'itservices')
 
 $jsonFile = ([IO.Path]::Combine("$PSScriptRoot", "test-namegenerator-itservices.json"))
 $classTester.runTests($jsonFile, $nameGenerator)
 
-# # # ------------------------------------------
-# # # Tests pour le tenant Reserach
+# ------------------------------------------
+# Tests pour le tenant Reserach
 
 $nameGenerator = [NameGenerator]::new('test', 'research')
 

--- a/powershell/tests/test-namegenerator.ps1
+++ b/powershell/tests/test-namegenerator.ps1
@@ -34,16 +34,16 @@ $nameGenerator = [NameGenerator]::new('test', 'epfl')
 $jsonFile = ([IO.Path]::Combine("$PSScriptRoot", "test-namegenerator-epfl.json"))
 $classTester.runTests($jsonFile, $nameGenerator)
 
-# ------------------------------------------
-# Tests pour le tenant ITServices
+# # ------------------------------------------
+# # Tests pour le tenant ITServices
 
 $nameGenerator = [NameGenerator]::new('test', 'itservices')
 
 $jsonFile = ([IO.Path]::Combine("$PSScriptRoot", "test-namegenerator-itservices.json"))
 $classTester.runTests($jsonFile, $nameGenerator)
 
-# # ------------------------------------------
-# # Tests pour le tenant Reserach
+# # # ------------------------------------------
+# # # Tests pour le tenant Reserach
 
 $nameGenerator = [NameGenerator]::new('test', 'research')
 


### PR DESCRIPTION
Ajout d'un nouveau niveau pour les groupes AD, afin de regrouper ceux-ci de manière logique en fonction de ce à quoi il servent

- [x] Si Eric OK pour ajouter un nouveau niveau d'OU, créer celles-ci à la main pour tous les environnements et déplacer les groupes existants au bon endroit
   - [x] EPFL >> Approval
   - [x] EPFL >> Support
   - [x] EPFL >> User
   - [x] ITServices >> Approval
   - [x] ITServices >> User
   - [x] Research >> Approval
   - [x] Research >> User

- Amélioration de la gestion du contenu des groupes. On supprime/ajoute à nouveau uniquement le nécessaire au lieu de vider complètement le groupe et de le remplir à nouveau. Plus efficace et plus rapide.
- Adaptation/amélioration de la classe de test pour le générateur de noms

# Issues
#165 - Ajout d'un nouveau niveau d'OU