### PR TITLE
Use Accred to fill support groups

### DIFF
--- a/powershell/config/.gitignore
+++ b/powershell/config/.gitignore
@@ -1,3 +1,4 @@
+config-accred.json
 config-billing.json
 config-global.json
 config-grants.json

--- a/powershell/config/config-accred-sample.json
+++ b/powershell/config/config-accred-sample.json
@@ -1,0 +1,23 @@
+{
+    "dev":
+    {
+        "server": "",
+        "appName": "",  // Nom de l'application cliente (nom du "compte" pour accéder)
+        "callerSciper": "", // Sciper de la personne pour laquelle on exécutera les commandes
+        "password": "" // mot de passe fourni par les admins de groups.epfl.ch pour "appName"
+    },
+    "test":
+    {
+        "server": "",
+        "appName": "",  // Nom de l'application cliente (nom du "compte" pour accéder)
+        "callerSciper": "", // Sciper de la personne pour laquelle on exécutera les commandes
+        "password": "" // mot de passe fourni par les admins de groups.epfl.ch pour "appName"
+    },
+    "prod":
+    {
+        "server": "",
+        "appName": "",  // Nom de l'application cliente (nom du "compte" pour accéder)
+        "callerSciper": "", // Sciper de la personne pour laquelle on exécutera les commandes
+        "password": "" // mot de passe fourni par les admins de groups.epfl.ch pour "appName"
+    }
+}

--- a/powershell/include/EPFLLDAP.inc.ps1
+++ b/powershell/include/EPFLLDAP.inc.ps1
@@ -283,8 +283,7 @@ class EPFLLDAP
 		# Parcours des informations que l'on a
 		ForEach($ldapInfos in $this.LDAPconfig.facultyUnits.locations)
 		{
-
-			# Recherche des unités de manière récursive
+			# Recherche de l'unité
 			$unit = $this.LDAPSearch($this.LDAPconfig.facultyUnits.server, $ldapInfos.rootDN, "subtree", `
 									("(&(objectClass=organizationalUnit)(uniqueidentifier={0}))" -f $unitUniqueIdentifier), @("*"))
 
@@ -295,6 +294,42 @@ class EPFLLDAP
 		}
 
 		return $null
+	}
 
+
+	<#
+	-------------------------------------------------------------------------------------
+		BUT : Retourne les informations d'une personne
+
+		IN  : $sciper	-> Sciper de la personne recherchée
+
+		RET : Objet avec les informations suivantes
+				- description
+				- uniqueidentifier
+				- memberuid
+				- displayname
+				- member
+				- cn
+				- memberuniqueid
+				- adspath
+				- objectclass
+				- gidnumber
+	#>
+	[PSObject] getPersonInfos([string]$sciper)
+	{
+		# Parcours des informations que l'on a
+		ForEach($ldapInfos in $this.LDAPconfig.facultyUnits.locations)
+		{
+			# Recherche de la personne de manière récursive
+			$person = $this.LDAPSearch($this.LDAPconfig.facultyUnits.server, $ldapInfos.rootDN, "subtree", `
+									("(&(objectClass=organizationalPerson)(uniqueidentifier={0}))" -f $sciper), @("*"))
+
+			if($person.count -eq 1)
+			{
+				return $person[0].Properties
+			}
+		}
+
+		return $null
 	}
 }

--- a/powershell/include/REST/AccredAPI.inc.ps1
+++ b/powershell/include/REST/AccredAPI.inc.ps1
@@ -1,0 +1,131 @@
+<#
+    BUT : Contient les fonctions donnant accès à l'API de accred.epfl.ch
+
+    Documentation: 
+        - API: https://websrv.epfl.ch/RWSAccreds.html
+
+    Prérequis:
+        - Il faut inclure le fichier incude/functions.inc.ps1
+
+    AUTEUR : Lucien Chaboudez
+    DATE   : Décembre 2020
+
+
+#>
+class AccredAPI: RESTAPICurl
+{
+
+    hidden [string] $appName
+    hidden [string] $password
+    hidden [EPFLLDAP] $ldap
+
+    <#
+	-------------------------------------------------------------------------------------
+		BUT : Créer une instance de l'objet et ouvre une connexion au serveur
+
+		IN  : $server			-> Nom DNS du serveur
+		IN  : $appName  	    -> Nom de l'application qui va appeler l'API
+        IN  : $password         -> Le mot de passe
+	#>
+	AccredAPI([string] $server, [string] $appName,  [string]$password, [EPFLLDAP]$ldap) : base($server) # Ceci appelle le constructeur parent
+	{
+        $this.headers.Add('Accept', 'application/json')
+        $this.headers.Add('Content-Type', 'application/x-www-form-urlencoded')
+        
+        $this.appName = $appName
+        $this.password = $password
+        $this.ldap = $ldap
+
+        # L'API sur https://accreds.epfl.ch ne supporte pas l'UTF-8 donc on utilise l'encodage par défaut
+        $this.usePSDefaultEncoding()
+    }
+
+
+    <#
+		-------------------------------------------------------------------------------------
+        BUT : Renvoie l'URL de base pour une commande. On y ajoutera ensuite d'autres paramètres
+                pour compléter la commande que l'on désire faire.
+
+		IN  : $command -> la commande que l'on veut exécuter
+
+		RET : URL 
+    #>
+    hidden [string] getBaseURI([string]$command)
+    {
+        # Le sciper du caller peut rester à 000000 car c'est uniquement de la lecture et pas de l'écriture.
+        return ("https://{0}/cgi-bin/rwsaccred/{1}?app={2}&caller=000000&password={3}" -f $this.server, $command, $this.appName, $this.password)
+    }
+
+
+    <#
+		-------------------------------------------------------------------------------------
+		BUT : Effectue un appel à l'API REST et contrôle s'il y a une erreur
+
+		IN  : $uri		-> URL à appeler
+        IN  : $method	-> Méthode à utiliser (Post, Get, Put, Delete)
+        
+        RET : Retour de l'appel
+
+        NOTE: Pas de "body" car cette API ne permet que de faire des requêtes GET (ça serait trop
+                beau qu'on puisse faire du PUT dans Accred XD )
+	#>
+    hidden [Object] callAPI([string]$uri, [string]$method)
+    {
+
+        $response = ([RESTAPICurl]$this).callAPI($uri, $method, $null)
+
+        # Si une erreur a été renvoyée 
+        if(objectPropertyExists -obj $response -propertyName 'error')
+        {
+            Throw ("AccredAPI error: {0}" -f $response.error.text)
+        }
+
+        return $response
+    }
+
+
+    <#
+		-------------------------------------------------------------------------------------
+        BUT : Renvoie la list des personnes qui sont admins IT d'une unité. On prend aussi en compte
+                les personnes qui héritent de ce droit pour l'unité en question pas uniquement 
+                celles qui sont spécifiquement accréditées dans l'unité en tant que AdminIT
+
+		IN  : $unitId   -> ID de l'unité
+
+        RET : Liste des personnes
+    #>
+    [PSObject] getUnitITAdminList([string]$unitId)
+    {
+        $uri = "{0}&roleid=AdminIT&unitid={1}" -f $this.getBaseURI('getRoles'), $unitId
+
+        try
+        {
+            $list = $this.callAPI($uri, "GET")
+        }
+        catch
+        {
+            # Analyse du message d'erreur pour voir si le groupe n'est pas trouvé
+            if($_.Exception.Message -like ("*{0} doesn't exist*" -f $unitId))
+            {
+                return $null
+            }
+            # On continue la propagation de l'exception 
+            Throw
+        }
+
+        $personList = @()
+
+        # Parcours des no scipers renvoyés
+        $list.result | ForEach-Object {
+            $person = $this.ldap.getPersonInfos($_)
+
+            # Si la personne a été trouvée dans LDAP, ajout à la liste
+            if($null -ne $person)
+            {
+                $personList += $person
+            }
+        }
+        return $personList
+    }
+
+}


### PR DESCRIPTION
Afin d'être au plus proche de ce qui existe réellement, l'idée est de récupérer la liste des responsables informatiques dans Accred et de créer un groupe par BG dans ActiveDirectory pour y mettre les personnes qui sont habilitées à faire du support. Attendre cependant la validation d'Eric pour cette manière de fonctionner.

- [ ] Etendre la fonction `createADGroupWithContent` pour faire en sorte qu'elle puisse prendre 2 types de paramètres en entrée:
    - Nom de groupe ("groups"? )
    - Liste de personnes physiques

## Pour le tenant EPFL
- [ ] Ne plus créer les groupes dans Groups pour le support 
- [ ] Supprimer les groupes existants pour le support
   - [ ] Dans https://groups.epfl.ch
   - [ ] Dans ActiveDirectory

# Issues
#143 - Utilisation d'Accred pour récupérer la liste des responsables informatique d'une unité