### PR TITLE
Quick bugfix - Catalog Items

### DIFF
--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -1461,6 +1461,34 @@ class vRAAPI: RESTAPICurl
 
 	<#
 		-------------------------------------------------------------------------------------
+		BUT : Renvoie la liste des Items du catalogue (qui sont disponibles dans des
+				entitlements) selon les paramètres passés dans $queryParams
+
+		IN  : $queryParams	-> (Optionnel -> "") Chaine de caractères à ajouter à la fin
+										de l'URI afin d'effectuer des opérations supplémentaires.
+										Pas besoin de mettre le ? au début des $queryParams
+
+		RET : Tableau contenant les items
+	#>
+	hidden [Array] getEntitledCatalogItemListQuery([string] $queryParams)
+	{
+		$uri = "https://{0}/catalog-service/api/consumer/entitledCatalogItems/?page=1&limit=5000" -f $this.server
+
+		# Si un filtre a été passé, on l'ajoute
+		if($queryParams -ne "")
+		{
+			$uri = "{0}&{1}" -f $uri, $queryParams
+		}
+
+		# Retour de la liste mais on ne prend que les éléments qui existent encore.
+		$result = ($this.callAPI($uri, "Get", $null)).content 	
+
+		return $result
+	}
+
+
+	<#
+		-------------------------------------------------------------------------------------
 		BUT : Renvoie la liste des Items du catalogue selon les paramètres passés dans $queryParams
 
 
@@ -1472,7 +1500,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getCatalogItemListQuery([string] $queryParams)
 	{
-		$uri = "https://{0}/catalog-service/api/consumer/entitledCatalogItems/?page=1&limit=5000" -f $this.server
+		$uri = "https://{0}/catalog-service/api/catalogItems/?page=1&limit=5000" -f $this.server
 
 		# Si un filtre a été passé, on l'ajoute
 		if($queryParams -ne "")
@@ -1496,9 +1524,9 @@ class vRAAPI: RESTAPICurl
 
 		RET : Tableau contenant les items du catalogue
 	#>
-	[Array] getServiceCatalogItemList([PSObject] $service)
+	[Array] getServiceEntitledCatalogItemList([PSObject] $service)
 	{
-		return $this.getCatalogItemListQuery(("`$filter=service/id eq '{0}' and status eq 'PUBLISHED'" -f $service.id))
+		return $this.getEntitledCatalogItemListQuery(("`$filter=service/id eq '{0}' and status eq 'PUBLISHED'" -f $service.id))
 	}
 
 

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -713,7 +713,7 @@ function prepareAddMissingBGEntPublicServices
 				$logHistory.addLineAndDisplay(("--> (prepare) Service '{0}' has been denied but only for {1} catalog item(s), adding the others" -f $publicService.name, $deniedSvcInfos.items.count))
 
 				# Recherche de la liste des items de catalogue disponibles dans le service courant
-				$catalogItems = $vra.getServiceCatalogItemList($publicService)
+				$catalogItems = $vra.getServiceEntitledCatalogItemList($publicService)
 
 				# Ajout des items de catalogue qui peuvent être présents
 				$catalogItems | ForEach-Object {


### PR DESCRIPTION
Correction rapide d'un bug dans la récupération des Items de Catalogue. La manière de faire récupérait uniquement les éléments qui étaient déjà dans un entitlement, ce qui fonctionnait très bien.

Mais suite à la mise en ligne de #157 les choses fonctionnaient car les 2 éléments que l'on voulait ajouter étaient dans l'entitlement "VM (Public)" vu qu'il y avaient été ajoutés à la main (c'est le workaround qu'on avait mis en place). Donc, forcément, le code fonctionnait sans problème vu que c'était dans le workaround... 
Et une fois qu'on a viré de l'entitlement ces 2 éléments de catalogue, eh bien il n'était plus possible de les trouver... 🤦 du coup, ajout de code pour récupérer la liste des éléments de catalogue qui ne sont pas dans un Service, afin de pouvoir les ajouter à la liste.