### PR TITLE
Billing - add entity name in BG custom properties

### DIFF
--- a/powershell/include/NameGenerator.inc.ps1
+++ b/powershell/include/NameGenerator.inc.ps1
@@ -1787,4 +1787,41 @@ class NameGenerator: NameGeneratorBase
         return ("vra_{0}_tableau_epfl_AppGrpU" -f $this.getEnvShortName())
     }
 
+
+    <#
+    -------------------------------------------------------------------------------------
+        BUT : Renvoie le nom de l'entité à utiliser pour identifier le BG dans la facturation
+
+        RET : Le nom de l'entité pour la facturation
+    #>
+    [string] getBillingEntityName()
+    {
+        $entityName = ""
+
+        switch($this.tenant)
+        {
+            $global:VRA_TENANT__EPFL
+            {
+                $entityName = $this.getDetail('unitName').ToUpper()
+            }
+
+            $global:VRA_TENANT__ITSERVICES
+            {   
+                $entityName = $this.getDetail('serviceName').ToUpper()
+            }
+
+            $global:VRA_TENANT__RESEARCH
+            {
+                $entityName = $this.getDetail('projectId')
+            }
+
+            default
+            {
+                Throw("Unsupported Tenant ({0})" -f $this.tenant)
+            }
+        }
+
+        return $entityName
+    }
+
 }

--- a/powershell/include/billing/Billing.inc.ps1
+++ b/powershell/include/billing/Billing.inc.ps1
@@ -23,8 +23,6 @@ class Billing
 {
     hidden [SQLDB] $db
     hidden [string] $targetEnv
-    hidden [PSObject] $serviceList
-    hidden [EPFLLDAP] $ldap
     hidden [PSObject] $serviceBillingInfos
     hidden [Hashtable] $vraTenantList
     hidden [string] $vRODynamicTypeName 
@@ -38,8 +36,6 @@ class Billing
                                         Chaque objet a pour clef le nom du tenant et comme "contenu" le 
                                         nécessaire pour interroger le tenant
         IN  : $db                   -> Objet de la classe SQLDB permettant d'accéder aux données.
-        IN  : $ldap                 -> Connexion au LDAP pour récupérer les infos sur les unités
-        IN  : $serviceList          -> Objet avec la liste de services (chargé depuis le fichier JSON itservices.json)
         IN  : $serviceBillingInfos  -> Objet avec les informations de facturation pour le service 
                                         Ces informations se trouvent dans le fichier JSON "service.json" qui sont 
                                         dans le dossier data/billing/<service>/service.json
@@ -48,12 +44,10 @@ class Billing
 
 		RET : Instance de l'objet
 	#>
-    Billing([Hashtable]$vraTenantList, [SQLDB]$db, [EPFLLDAP]$ldap, [PSObject]$serviceList, [PSObject]$serviceBillingInfos, [string]$targetEnv, [string]$vRODynamicTypeName)
+    Billing([Hashtable]$vraTenantList, [SQLDB]$db, [PSObject]$serviceBillingInfos, [string]$targetEnv, [string]$vRODynamicTypeName)
     {
         $this.vraTenantList = $vraTenantList
         $this.db = $db
-        $this.ldap = $ldap
-        $this.serviceList = $serviceList
         $this.serviceBillingInfos = $serviceBillingInfos
         $this.targetEnv = $targetEnv
         $this.vRODynamicTypeName = $vRODynamicTypeName

--- a/powershell/include/define.inc.ps1
+++ b/powershell/include/define.inc.ps1
@@ -54,14 +54,15 @@ $global:VRA_SERVICE_SUFFIX__PUBLIC  =" (Public)"
 $global:VRA_SERVICE_SUFFIX__PRIVATE =" (Private)"
 
 # Nom des custom properties à utiliser
-$global:VRA_CUSTOM_PROP_EPFL_BG_ID                    = "ch.epfl.vra.bg.id"
-$global:VRA_CUSTOM_PROP_VRA_BG_TYPE                   = "ch.epfl.vra.bg.type"
-$global:VRA_CUSTOM_PROP_VRA_BG_STATUS                 = "ch.epfl.vra.bg.status"
-$global:VRA_CUSTOM_PROP_VRA_BG_RES_MANAGE             = "ch.epfl.vra.bg.res.manage"
-$global:VRA_CUSTOM_PROP_VRA_BG_ROLE_SUPPORT_MANAGE    = "ch.epfl.vra.bg.roles.support.manage"
-$global:VRA_CUSTOM_PROP_VRA_TENANT_NAME               = "ch.epfl.vra.tenant.name"
-$global:VRA_CUSTOM_PROP_VRA_BG_NAME                   = "ch.epfl.vra.bg.name"
-$global:VRA_CUSTOM_PROP_EPFL_BILLING_FINANCE_CENTER   = "ch.epfl.billing.financecenter"
+$global:VRA_CUSTOM_PROP_EPFL_BG_ID                  = "ch.epfl.vra.bg.id"
+$global:VRA_CUSTOM_PROP_VRA_BG_TYPE                 = "ch.epfl.vra.bg.type"
+$global:VRA_CUSTOM_PROP_VRA_BG_STATUS               = "ch.epfl.vra.bg.status"
+$global:VRA_CUSTOM_PROP_VRA_BG_RES_MANAGE           = "ch.epfl.vra.bg.res.manage"
+$global:VRA_CUSTOM_PROP_VRA_BG_ROLE_SUPPORT_MANAGE  = "ch.epfl.vra.bg.roles.support.manage"
+$global:VRA_CUSTOM_PROP_VRA_TENANT_NAME             = "ch.epfl.vra.tenant.name"
+$global:VRA_CUSTOM_PROP_VRA_BG_NAME                 = "ch.epfl.vra.bg.name"
+$global:VRA_CUSTOM_PROP_EPFL_BILLING_FINANCE_CENTER = "ch.epfl.billing.financecenter"
+$global:VRA_CUSTOM_PROP_EPFL_BILLING_ENTITY_NAME    = "ch.epfl.billing.entity.name"
 
 
 # Types de Business Group possibles

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -495,7 +495,7 @@ function determineUnitFinanceCenter([PSCustomObject]$unit, [Array]$unitList, [Ar
 	}
 	
 
-	# Si on doit utiliser une adresse mail pour la facturation au lieu du centre financier
+	# 1. Si on doit utiliser une adresse mail pour la facturation au lieu du centre financier
 	$financeCenter = $null
 	ForEach($billToMail in $billToMailList)
 	{
@@ -890,7 +890,7 @@ try
 						$logHistory.addLineAndDisplay(("-> [{0}/{1}] Unit {2} => {3}..." -f $unitNo, $unitList.$sourceType.Count, $faculty.name, $unit.name))
 
 						# Recherche du centre financier à utiliser
-						$financeCenter = determineUnitFinanceCenter -unit $unit -unitList $unitList -billToMailList $billToMailList `
+						$financeCenter = determineUnitFinanceCenter -unit $unit -unitList $unitList.$sourceType -billToMailList $billToMailList `
 										-sourceType $sourceType -geUnitMappingList $geUnitMappingList
 
 						$vRAServicesToDeny = @()

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -374,12 +374,19 @@ function createOrUpdateBG
 		# Si le BG n'a pas la custom property donnée, on l'ajoute
 		# FIXME: Cette partie de code pourra être enlevée au bout d'un moment car elle est juste prévue pour mettre à jours
 		# les BG existants avec la nouvelle "Custom Property"
-		if($null -eq (getBGCustomPropValue -bg $bg -customPropName $global:VRA_CUSTOM_PROP_EPFL_BILLING_ENTITY_NAME))
+		# if($null -eq (getBGCustomPropValue -bg $bg -customPropName $global:VRA_CUSTOM_PROP_EPFL_BILLING_ENTITY_NAME))
+		# {
+		# 	# Ajout de la custom Property avec la valeur par défaut 
+		# 	$bg = $vra.updateBG($bg, $bgName, $bgDesc, $machinePrefixId, @{"$global:VRA_CUSTOM_PROP_EPFL_BILLING_ENTITY_NAME" = $nameGenerator.getBillingEntityName()})
+		# }
+
+
+		# Si le nom de l'entité de facturation a changé (ce qui peut arriver), on la met à jour
+		if((getBGCustomPropValue -bg $bg -customPropName $global:VRA_CUSTOM_PROP_EPFL_BILLING_ENTITY_NAME) -ne $nameGenerator.getBillingEntityName())
 		{
-			# Ajout de la custom Property avec la valeur par défaut 
+			# Mise à jour
 			$bg = $vra.updateBG($bg, $bgName, $bgDesc, $machinePrefixId, @{"$global:VRA_CUSTOM_PROP_EPFL_BILLING_ENTITY_NAME" = $nameGenerator.getBillingEntityName()})
 		}
-
 
 		# ==========================================================================================
 

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -374,10 +374,10 @@ function createOrUpdateBG
 		# Si le BG n'a pas la custom property donnée, on l'ajoute
 		# FIXME: Cette partie de code pourra être enlevée au bout d'un moment car elle est juste prévue pour mettre à jours
 		# les BG existants avec la nouvelle "Custom Property"
-		if($null -eq (getBGCustomPropValue -bg $bg -customPropName $global:VRA_CUSTOM_PROP_EPFL_BG_ID))
+		if($null -eq (getBGCustomPropValue -bg $bg -customPropName $global:VRA_CUSTOM_PROP_EPFL_BILLING_ENTITY_NAME))
 		{
 			# Ajout de la custom Property avec la valeur par défaut 
-			$bg = $vra.updateBG($bg, $bgName, $bgDesc, $machinePrefixId, @{"$global:VRA_CUSTOM_PROP_EPFL_BG_ID" = $bgEPFLID})
+			$bg = $vra.updateBG($bg, $bgName, $bgDesc, $machinePrefixId, @{"$global:VRA_CUSTOM_PROP_EPFL_BILLING_ENTITY_NAME" = $nameGenerator.getBillingEntityName()})
 		}
 
 

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -270,8 +270,6 @@ function create2ndDayActionApprovalPolicies([vRAAPI]$vra, [SecondDayActions]$sec
 	BUT : Créé (si inexistant) ou met à jour un Business Group (si existant)
 
 	IN  : $vra 					-> Objet de la classe vRAAPI permettant d'accéder aux API vRA
-	IN  : $existingBGList		-> Tableau associatif avec la liste des BG, aura été créé via la fonction 
-									createMappingBGList
 	IN  : $tenantName			-> Nom du tenant sur lequel on bosse
 	IN  : $bgEPFLID				-> ID du BG défini par l'EPFL et pas vRA. Valable pour les BG qui sont sur tous les tenants
 	IN  : $bgName				-> Nom du BG
@@ -285,10 +283,10 @@ function create2ndDayActionApprovalPolicies([vRAAPI]$vra, [SecondDayActions]$sec
 #>
 function createOrUpdateBG
 {
-	param([vRAAPI]$vra, [Hashtable]$existingBGList, [string]$tenantName, [string]$bgEPFLID, [string]$bgName, [string]$bgDesc, [string]$machinePrefixName, [string]$financeCenter, [string]$capacityAlertsEmail)
+	param([vRAAPI]$vra, [string]$tenantName, [string]$bgEPFLID, [string]$bgName, [string]$bgDesc, [string]$machinePrefixName, [string]$financeCenter, [string]$capacityAlertsEmail)
 
 	# Recherche du BG par son no identifiant (no d'unité, no de service Snow, etc... ).
-	$bg = getBGFromMappingList -mappingList $existingBGList -customPropValue $bgEPFLID
+	$bg = $vra.getBGByCustomId($bgEPFLID, $true)
 
 
 	# ---- EPFL ---- ou ---- Research ----
@@ -1261,69 +1259,6 @@ function createFirewallSectionRulesIfNotExists
 
 
 <#
--------------------------------------------------------------------------------------
-	BUT : Prend une liste des BG et créé un mapping entre la valeur de la custom
-			property donnée et le BG. On fait ceci pour avoir à éviter de parcourir
-			N fois la liste de BG pour chercher s'il existe. Là, on pourra accéder
-			directement via la valeur de la custom property donc ça sera plus rapide.
-
-	IN  : $bgList			-> La liste des BG pour laquelle créer le mapping
-	IN  : $customPropName	-> Le nom de la custom property à chercher
-
-	RET : Tableau associatif avec en clef la valeur de la custom property cherchée préfixée
-			avec _ histoire d'avoir un caractère autorisé pour commencer le nom de la clef.
-			Et en valeur, on trouve le BG.
-#>
-function createMappingBGList([Array]$bgList, [string]$customPropName)
-{
-	$mappingList = @{}
-
-	$logHistory.addLineAndDisplay(("Creating mapping list for {0} Business Groups..." -f $bgList.count))
-	# Parcours des BG
-	ForEach($bg in $bgList)
-	{
-		# Récupération de la valeur de la customProperty
-		$propValue = getBGCustomPropValue -bg $bg -customPropName $customPropName
-
-		if($null -ne $propValue)
-		{
-			# Création d'un nom de clef pour qu'elle commence avec un caractères autorisé
-			$key = "_{0}" -f $propValue
-
-			$mappingList.$key = $bg
-		}
-	}
-
-	return $mappingList
-}
-
-
-<#
--------------------------------------------------------------------------------------
-	BUT : Renvoie le BG correspondant à la valeur de custom property passée
-
-	IN  : $mappingList			-> La liste de mapping qui aura été générée par la
-									fonction createMappingBGList
-	IN  : $customPropValue		-> Valeur de la custom property pour laquelle on veut le BG
-
-	RET : Le BG
-			$null si pas trouvé
-#>
-function getBGFromMappingList([Hashtable]$mappingList, [string]$customPropValue)
-{
-	# Génération de la clef de recherche
-	$key = "_{0}" -f $customPropValue
-
-	# Si la clef existe, retour du résultat
-	if($mappingList.Keys -contains $key)
-	{
-		return $mappingList.$key
-	}
-	return $null
-}
-
-
-<#
 	-------------------------------------------------------------------------------------
 	-------------------------------------------------------------------------------------
 	-------------------------------------------------------------------------------------
@@ -1442,12 +1377,6 @@ try
 	# Création d'une connexion au serveur NSX pour accéder aux API REST de NSX
 	$logHistory.addLineAndDisplay("Connecting to NSX-T...")
 	$nsx = [NSXAPI]::new($configNSX.getConfigValue($targetEnv, "server"), $configNSX.getConfigValue($targetEnv, "user"), $configNSX.getConfigValue($targetEnv, "password"))
-
-	# Recherche de BG existants 
-	$existingBGList = $vra.getBGList()
-
-	# Création de la liste de mapping
-	$customPropToExistingBGMapping = createMappingBGList -bgList $existingBGList -customPropName $global:VRA_CUSTOM_PROP_EPFL_BG_ID
 
 	$doneBGList = @()
 
@@ -1716,7 +1645,7 @@ try
 		# --------------------------------- Business Group 
 
 		# Création ou mise à jour du Business Group
-		$bg = createOrUpdateBG -vra $vra -existingBGList $customPropToExistingBGMapping -bgEPFLID $bgEPFLID -tenantName $targetTenant -bgName $bgName -bgDesc $bgDesc `
+		$bg = createOrUpdateBG -vra $vra -bgEPFLID $bgEPFLID -tenantName $targetTenant -bgName $bgName -bgDesc $bgDesc `
 									-machinePrefixName $machinePrefixName -financeCenter $financeCenter -capacityAlertsEmail ($capacityAlertMails -join ",") 
 
 		# Si BG pas créé, on passe au suivant (la fonction de création a déjà enregistré les infos sur ce qui ne s'est pas bien passé)

--- a/powershell/xaas-billing.ps1
+++ b/powershell/xaas-billing.ps1
@@ -47,8 +47,6 @@ param([string]$targetEnv,
 . ([IO.Path]::Combine("$PSScriptRoot", "include", "NotificationMail.inc.ps1"))
 . ([IO.Path]::Combine("$PSScriptRoot", "include", "Counters.inc.ps1"))
 . ([IO.Path]::Combine("$PSScriptRoot", "include", "SQLDB.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "EPFLLDAP.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "ITServices.inc.ps1"))
 . ([IO.Path]::Combine("$PSScriptRoot", "include", "SecondDayActions.inc.ps1"))
 . ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "APIUtils.inc.ps1"))
 . ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPI.inc.ps1"))
@@ -271,9 +269,6 @@ try
                         $configVra.getConfigValue($targetEnv, "db", "password"), `
                         $configVra.getConfigValue($targetEnv, "db", "port"))
 
-    # Pour accéder à LDAP, sera utilisé plus bas
-    $ldap = [EPFLLDAP]::new()
-
     $vraTenantList = @{}
 
     # Créatino des connexions à vRA pour chaque tenant à facturer
@@ -287,13 +282,6 @@ try
                                             $configVra.getConfigValue($targetEnv, "infra", $tenant, "password"))
     }
 
-    
-
-    # Objet pour lire les informations sur le services IT
-    $itServices = [ITServices]::new()
-
-    # On prend la liste correspondant à l'environnement sur lequel on se trouve
-    $itServicesList = $itServices.getServiceList($targetEnv)
 
     # Fichier JSON contenant les détails du service que l'on veut facturer    
     $serviceBillingInfosFile = ([IO.Path]::Combine("$PSScriptRoot", "data", "billing", $service.ToLower(), "service.json"))
@@ -309,7 +297,7 @@ try
 
     # Création de l'objet pour faire les opérations pour le service donné. On le créée d'une manière dynamique en utilisant la bonne classe
     # en fonction du type de service à facturer
-    $expression = '$billingObject = [{0}]::new($vraTenantList, $sqldb, $ldap, $itServicesList, $serviceBillingInfos, $targetEnv)' -f $serviceBillingInfos.billingClassName
+    $expression = '$billingObject = [{0}]::new($vraTenantList, $sqldb, $serviceBillingInfos, $targetEnv)' -f $serviceBillingInfos.billingClassName
     Invoke-expression $expression
 
     # Pour accéder à Copernic

--- a/powershell/xaas-billing.ps1
+++ b/powershell/xaas-billing.ps1
@@ -257,8 +257,8 @@ try
 	(cette liste sera accédée en variable globale même si c'est pas propre XD)
 	#>
     $notifications=@{
-        copernicBillError = @()
         incorrectFinanceCenter = @()
+        copernicBillNotSent = @()
     }
 
     # Pour accéder à la base de données


### PR DESCRIPTION
- Ajout d'un cache pour la recherche de Business Group par son ID. L'ID étant dans une "custom property" (`ch.epfl.vra.bg.id`), cela prend monstre temps (👹) de faire la recherche à chaque fois... donc là, on peut choisir d'utiliser le cache pour optimiser la chose. C'est utilisé pour la partie de facturation
- Ajout d'une nouvelle "custom property" avec pour nom `ch.epfl.billing.entity.name` qui contiendra le nom de l'élément à facturer. Donc soit un nom d'unité, un nom (long) de service, ou un numéro de projet (suivant le tenant sur lequel on fait la facturation).
- Utilisation de la nouvelle custom property lors de la partie `extractData` de la facturation. Avant, on allait piocher dans LDAP et le fichier JSON mais ce n'est pas le bon endroit pour récupérer les données. Celles-ci suivent un "cheminement" depuis LDAP/JSON vers AD , puis vers vRA donc dans la logique, il faut utiliser ce qui est dans vRA. Passer par LDAP pour le tenant EPFL entraînait un problème pour la facturation des BG "Admin" du fait qu'ils n'ont pas de no d'unité "valable", donc une erreur était générée lors de l'extraction des données. Bug introduit dans #145 
- Correction d'un nom de compteur incorrect
- Correction d'un bug dans la récupération du centre financier d'une unité de niveau 4 (introduit dans #145)