### PR TITLE
Add notification for missing day2 actions

### DIFF
--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -1012,10 +1012,15 @@ class vRAAPI: RESTAPICurl
 		IN  : $ent				-> Objet de l'entitlement auquel ajouter les actions
 		IN  : $secondDayActions	-> Objet de la classe SecondDayActions contenant la liste des actions à ajouter.
 
-		RET : Objet contenant l'Entitlement avec les actions passée.
+		RET : Tableau associatif avec les éléments suivants:
+				.entitlement		-> Objet contenant l'Entitlement avec les actions passée.
+				.notFoundActions	-> Tableau avec la liste des actions non trouvées
 	#>
-	[PSCustomObject] prepareEntActions([PSCustomObject] $ent, [SecondDayActions]$secondDayActions)
+	[Hashtable] prepareEntActions([PSCustomObject] $ent, [SecondDayActions]$secondDayActions)
 	{
+		# Pour enregistrer la liste des actions non trouvées
+		$notFoundActions = @()
+
 		# Pour stocker la liste des actions à ajouter, avec toutes les infos nécessaires
 		$actionsToAdd = @()
 
@@ -1045,6 +1050,12 @@ class vRAAPI: RESTAPICurl
 				else # Pas d'infos trouvées pour l'action
 				{
 					Write-Warning ("prepareEntActions(): No information found for action '{0}' for element '{1}'" -f $actionName, $targetElementName)
+					
+					if($notFoundActions -notcontains $actionName)
+					{
+						$notFoundActions += $actionName
+					}
+					
 				}
 			} # Fin BOUCLE de parcours des actions pour l'élément courant 
 			
@@ -1054,7 +1065,10 @@ class vRAAPI: RESTAPICurl
 		$ent.entitledResourceOperations = $actionsToAdd
 
 		# Retour de l'entitlement avec les actions
-		return $ent
+		return @{
+			entitlement = $ent
+			notFoundActions = $notFoundActions
+		}
 	}
 
 

--- a/powershell/resources/mail-templates/day2-actions-not-found.html
+++ b/powershell/resources/mail-templates/day2-actions-not-found.html
@@ -1,0 +1,5 @@
+Les action "Day 2" suivante n'ont pas été trouvés au moment de créer les entitlements:
+<br>
+<ul>
+    <li>{{actionList}}</li>
+</ul>

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1053,7 +1053,15 @@ function handleNotifications
 					$valToReplace.itemList = ($uniqueNotifications -join "</li>`n<li>")
 					$mailSubject = "Error - Mandatory catalog items not found"
 					$templateName = "mandatory-catalog-items-not-found"
-					
+				}
+
+				# ---------------------------------------
+				# Liste des actions "day-2" non trouvées
+				'notFound2ndDayActions'
+				{
+					$valToReplace.actionList = ($uniqueNotifications -join "</li>`n<li>")
+					$mailSubject = "Error - Second day actions not found"
+					$templateName = "day2-actions-not-found"
 				}
 
 				default
@@ -1368,7 +1376,9 @@ try
 					emptyADGroups = @()
 					adGroupsNotFound = @()
 					ISOFolderNotRenamed = @()
-					mandatoryItemsNotFound = @()}
+					mandatoryItemsNotFound = @()
+					notFound2ndDayActions = @()
+				}
 
 
 	$logHistory.addLineAndDisplay(("Executed with parameters: Environment={0}, Tenant={1}" -f $targetEnv, $targetTenant))
@@ -1698,7 +1708,11 @@ try
 		# ----------------------------------------------------------------------------------
 		# --------------------------------- Business Group Entitlement - 2nd day Actions
 		$logHistory.addLineAndDisplay("-> (prepare) Adding 2nd day Actions to Entitlement...")
-		$ent = $vra.prepareEntActions($ent, $secondDayActions)
+		$result = $vra.prepareEntActions($ent, $secondDayActions)
+		$ent = $result.entitlement
+		# Mise à jour de la liste des actions non trouvées
+		$notifications.notFound2ndDayActions += $result.notFoundActions
+
 		
 		# ----------------------------------------------------------------------------------
 		# --------------------------------- Business Group Entitlement - Services


### PR DESCRIPTION
Ajout d'une notification par email pour les actions "day2" qui ne sont pas trouvées lorsque l'on créé les entitlements. Jusqu'à présent, seul un warning était affiché par le script.