### PR TITLE
Change way to access config values

### DIFF
--- a/powershell/clean-ghost-bg.ps1
+++ b/powershell/clean-ghost-bg.ps1
@@ -372,14 +372,14 @@ try
 		targetEnv = $targetEnv
 		targetTenant = $targetTenant
 	}
-	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MAIL_TEMPLATE_FOLDER, `
+	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, 
 												($global:VRA_MAIL_SUBJECT_PREFIX -f $targetEnv, $targetTenant), $valToReplace)
 
 	# Pour s'interfacer avec l'application Groups
-	$groupsApp = [GroupsAPI]::new($configGroups.getConfigValue($targetEnv, "server"),`
-								  $configGroups.getConfigValue($targetEnv, "appName"),`
-								   $configGroups.getConfigValue($targetEnv, "callerSciper"),`
-								   $configGroups.getConfigValue($targetEnv, "password"))
+	$groupsApp = [GroupsAPI]::new($configGroups.getConfigValue(@($targetEnv, "server")),
+								  $configGroups.getConfigValue(@($targetEnv, "appName")),
+								   $configGroups.getConfigValue(@($targetEnv, "callerSciper")),
+								   $configGroups.getConfigValue(@($targetEnv, "password")))
 
 	<# Pour enregistrer des notifications à faire par email. Celles-ci peuvent être informatives ou des erreurs à remonter
 	aux administrateurs du service
@@ -400,14 +400,16 @@ try
 	
 	# Création d'une connexion au serveur vRA pour accéder à ses API REST
 	$logHistory.addLineAndDisplay("Connecting to vRA...")
-	$vra = [vRAAPI]::new($configVra.getConfigValue($targetEnv, "infra", "server"), 
+	$vra = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")), 
 						 $targetTenant, 
-						 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "user"), 
-						 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "password"))
+						 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "user")), 
+						 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "password")))
 
 	# Création d'une connexion au serveur NSX pour accéder aux API REST de NSX
 	$logHistory.addLineAndDisplay("Connecting to NSX-T...")
-	$nsx = [NSXAPI]::new($configNSX.getConfigValue($targetEnv, "server"), $configNSX.getConfigValue($targetEnv, "user"), $configNSX.getConfigValue($targetEnv, "password"))
+	$nsx = [NSXAPI]::new($configNSX.getConfigValue(@($targetEnv, "server")), 
+						 $configNSX.getConfigValue(@($targetEnv, "user")), 
+						 $configNSX.getConfigValue(@($targetEnv, "password")))
 
 
 	$logHistory.addLineAndDisplay("Cleaning 'old' Business Groups")

--- a/powershell/clean-iso-folders.ps1
+++ b/powershell/clean-iso-folders.ps1
@@ -124,7 +124,7 @@ try
 		targetEnv = $targetEnv
 		targetTenant = $targetTenant
 	}
-	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MAIL_TEMPLATE_FOLDER, `
+	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, 
 												($global:VRA_MAIL_SUBJECT_PREFIX -f $targetEnv, $targetTenant), $valToReplace)
 
 	# Création d'un objet pour gérer les compteurs (celui-ci sera accédé en variable globale même si c'est pas propre XD)
@@ -156,10 +156,10 @@ try
 		# Si on n'a pas encore de connexion à vRA, là, ça serait bien d'en ouvrir une histoire pouvoir continuer.
 		if($null -eq $vra)
 		{
-			$vra = [vRAAPI]::new($configVra.getConfigValue($targetEnv, "infra", "server"), 
+			$vra = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")), 
 								$targetTenant, 
-								$configVra.getConfigValue($targetEnv, "infra", $targetTenant, "user"), 
-								$configVra.getConfigValue($targetEnv, "infra", $targetTenant, "password"))
+								$configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "user")), 
+								$configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "password")))
 		}	
 
 		# Si on n'a pas encore de connexin à vCenter, c'est aussi maintenant qu'on va l'établir. Enfin, on pourrait faire ça plus tard dans le code mais vu qu'on vient
@@ -173,10 +173,10 @@ try
 			# bidon sinon c'est affiché à l'écran.
 			Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -Confirm:$false | Out-Null
 
-			$credSecurePwd = $configVSphere.getConfigValue($targetEnv, "password") | ConvertTo-SecureString -AsPlainText -Force
-			$credObject = New-Object System.Management.Automation.PSCredential -ArgumentList $configVSphere.getConfigValue($targetEnv, "user"), $credSecurePwd	
+			$credSecurePwd = $configVSphere.getConfigValue(@($targetEnv, "password")) | ConvertTo-SecureString -AsPlainText -Force
+			$credObject = New-Object System.Management.Automation.PSCredential -ArgumentList $configVSphere.getConfigValue(@($targetEnv, "user")), $credSecurePwd	
 
-			$vCenter = Connect-VIServer -Server $configVSphere.getConfigValue($targetEnv, "server") -Credential $credObject
+			$vCenter = Connect-VIServer -Server $configVSphere.getConfigValue(@($targetEnv, "server")) -Credential $credObject
 		}
 		
 		# Recherche des infos du BG

--- a/powershell/iaas/IaaS-Template-Sync-sites.ps1
+++ b/powershell/iaas/IaaS-Template-Sync-sites.ps1
@@ -34,7 +34,7 @@ $configVcenter = [ConfigReader]::New("config-vsphere.json")
 
 try {
 	
-	$vCenter = Connect-VIServer -Server ($configVcenter.getConfigValue($targetEnv, "server")) -user ($configVcenter.getConfigValue($targetEnv, "user")) -password ($configVcenter.getConfigValue($targetEnv, "password"))
+	$vCenter = Connect-VIServer -Server ($configVcenter.getConfigValue(@($targetEnv, "server"))) -user ($configVcenter.getConfigValue(@($targetEnv, "user"))) -password ($configVcenter.getConfigValue(@($targetEnv, "password")))
 						 
 
 }
@@ -59,15 +59,15 @@ If ( (Get-module vmware.powercli ) -like "" ) {
 ### code
 
 ## set master templates from configuration files
-$masterTemplatesFolderName = $configVsphereTemplate.getConfigValue($targetEnv, "masterTemplatesFolder")
-$masterTemplatesTag = $configVsphereTemplate.getConfigValue($targetEnv, "masterTemplatesTag")
+$masterTemplatesFolderName = $configVsphereTemplate.getConfigValue(@($targetEnv, "masterTemplatesFolder"))
+$masterTemplatesTag = $configVsphereTemplate.getConfigValue(@($targetEnv, "masterTemplatesTag"))
 
 $masterTemplatesFolder = get-folder -name $masterTemplatesFolderName  -Type VM -Server $vCenter
 $masterTemplates = Get-Template -location $masterTemplatesFolder -Server $vCenter | Sort-Object
 
 ## get templates targets from configuration file
 
-$TemplatesTargets = $configVsphereTemplate.getConfigValue($targetEnv, "TemplatesTargets") | Get-Member -MemberType NoteProperty | Select-object -ExpandProperty Name 
+$TemplatesTargets = $configVsphereTemplate.getConfigValue(@($targetEnv, "TemplatesTargets")) | Get-Member -MemberType NoteProperty | Select-object -ExpandProperty Name 
 
 ## loop for each master template
 
@@ -88,20 +88,20 @@ foreach ($vmtag in $vmtags) {
 
 
 ## set replica informations
-$replicaTemplatesFolderName = $configVsphereTemplate.getConfigValue($targetEnv, "TemplatesTargets", $TemplatesTarget, "replicaTemplatesFolder")
+$replicaTemplatesFolderName = $configVsphereTemplate.getConfigValue(@($targetEnv, "TemplatesTargets", $TemplatesTarget, "replicaTemplatesFolder"))
 $replicaTemplatesFolder = get-folder -name $replicaTemplatesFolderName  -Type VM -Server $vCenter
 
-$replicaClusterName = $configVsphereTemplate.getConfigValue($targetEnv, "TemplatesTargets", $TemplatesTarget, "replicaCluster")
+$replicaClusterName = $configVsphereTemplate.getConfigValue(@($targetEnv, "TemplatesTargets", $TemplatesTarget, "replicaCluster"))
 $replicaVMHost = Get-VMHost -location (get-cluster -name $replicaClusterName) | get-random -Count 1
 
-$replicaDSName = $configVsphereTemplate.getConfigValue($targetEnv, "TemplatesTargets", $TemplatesTarget, "replicaDSName")
+$replicaDSName = $configVsphereTemplate.getConfigValue(@($targetEnv, "TemplatesTargets", $TemplatesTarget, "replicaDSName"))
 $replicaTemplatesDatastore = $replicaVMHost | Get-Datastore -Server $vCenter | Where-Object {($_.name -like $replicaDSName) -and ($_.Type -like "VMFS")}
 
 
 $replicaTemplates = Get-Template -location $replicaTemplatesFolder -Server $vCenter
 $newReplicaTemplates = @()
 
-$replicaTemplatesSuffixName = $configVsphereTemplate.getConfigValue($targetEnv, "TemplatesTargets", $TemplatesTarget, "replicaTemplatesSuffix")
+$replicaTemplatesSuffixName = $configVsphereTemplate.getConfigValue(@($targetEnv, "TemplatesTargets", $TemplatesTarget, "replicaTemplatesSuffix"))
 
 
 

--- a/powershell/include/ConfigReader.inc.ps1
+++ b/powershell/include/ConfigReader.inc.ps1
@@ -54,20 +54,6 @@ class ConfigReader
 
    <#
 	-------------------------------------------------------------------------------------
-      BUT : Renvoie une valeur de configuration pour un élément donné par son nom. Il
-            se trouve donc à la racine
-      
-      IN  : $rootElement  -> Nom de l'élément à la racine
-
-      RET : Valeur demandée
-	#>
-   [PSObject]getConfigValue([string]$rootElement)
-   {
-      return $this.getConfigValue(@($rootElement))
-   }
-
-   <#
-	-------------------------------------------------------------------------------------
       BUT : Renvoie une valeur de configuration pour un élément donné par son chemin
       
       IN  : $pathToVal  -> Tableau avec le chemin jusqu'à la valeur recherchée

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -654,22 +654,22 @@ try
 		targetEnv = $targetEnv
 		targetTenant = $targetTenant
 	}
-	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MAIL_TEMPLATE_FOLDER, `
+	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, `
 												($global:VRA_MAIL_SUBJECT_PREFIX -f $targetEnv, $targetTenant), $valToReplace)
 
 	# Pour s'interfacer avec l'application Groups
-	$groupsApp = [GroupsAPI]::new($configGroups.getConfigValue($targetEnv, "server"),`
-								  $configGroups.getConfigValue($targetEnv, "appName"),`
-								   $configGroups.getConfigValue($targetEnv, "callerSciper"),`
-								   $configGroups.getConfigValue($targetEnv, "password"))
+	$groupsApp = [GroupsAPI]::new($configGroups.getConfigValue(@($targetEnv, "server")),
+								  $configGroups.getConfigValue(@($targetEnv, "appName")),
+								   $configGroups.getConfigValue(@($targetEnv, "callerSciper")),
+								   $configGroups.getConfigValue(@($targetEnv, "password")))
 	
 	# Pour accéder à la base de données
-	$sqldb = [SQLDB]::new([DBType]::MSSQL, `
-							$configVra.getConfigValue($targetEnv, "db", "host"), `
-							$configVra.getConfigValue($targetEnv, "db", "dbName"), `
-							$configVra.getConfigValue($targetEnv, "db", "user"), `
-							$configVra.getConfigValue($targetEnv, "db", "password"), `
-							$configVra.getConfigValue($targetEnv, "db", "port"))
+	$sqldb = [SQLDB]::new([DBType]::MSSQL, 
+							$configVra.getConfigValue(@($targetEnv, "db", "host")),
+							$configVra.getConfigValue(@($targetEnv, "db", "dbName")),
+							$configVra.getConfigValue(@($targetEnv, "db", "user")), 
+							$configVra.getConfigValue(@($targetEnv, "db", "password")),
+							$configVra.getConfigValue(@($targetEnv, "db", "port")))
 
 	Import-Module ActiveDirectory
 
@@ -1325,12 +1325,12 @@ try
 			$counters.add('rsrch.projectSkipped', '# Projects skipped')
 
 			# Pour accéder à la base de données
-			$mysqlGrants = [SQLDB]::new([DBType]::MySQL, `
-										$configGrants.getConfigValue($targetEnv, "host"), `
-										$configGrants.getConfigValue($targetEnv, "dbName"), `
-										$configGrants.getConfigValue($targetEnv, "user"), `
-										$configGrants.getConfigValue($targetEnv, "password"), `
-										$configGrants.getConfigValue($targetEnv, "port"))
+			$mysqlGrants = [SQLDB]::new([DBType]::MySQL, 
+										$configGrants.getConfigValue(@($targetEnv, "host")),
+										$configGrants.getConfigValue(@($targetEnv, "dbName")),
+										$configGrants.getConfigValue(@($targetEnv, "user")),
+										$configGrants.getConfigValue(@($targetEnv, "password")),
+										$configGrants.getConfigValue(@($targetEnv, "port")))
 
 			$projectList = $mysqlGrants.execute("SELECT * FROM v_gdb_iaas WHERE subsides_start_date <= DATE(NOW()) AND subsides_end_date > DATE(NOW())")
 			# Décommenter la ligne suivante et éditer l'ID pour simuler la disparition d'un projet
@@ -1579,10 +1579,10 @@ try
 		Start-Sleep -Seconds $sleepDurationSec
 		try {
 			# Création d'une connexion au serveur
-			$vra = [vRAAPI]::new($configVra.getConfigValue($targetEnv, "infra", "server"), 
+			$vra = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")),
 								 $targetTenant, 
-								 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "user"), 
-								 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "password"))
+								 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "user")),
+								 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "password")))
 		}
 		catch {
 			Write-Error "Error connecting to vRA API !"

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1319,7 +1319,7 @@ try
 		targetEnv = $targetEnv
 		targetTenant = $targetTenant
 	}
-	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MAIL_TEMPLATE_FOLDER, `
+	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, `
 												($global:VRA_MAIL_SUBJECT_PREFIX -f $targetEnv, $targetTenant), $valToReplace)
 
 
@@ -1386,14 +1386,16 @@ try
 	
 	# Création d'une connexion au serveur vRA pour accéder à ses API REST
 	$logHistory.addLineAndDisplay("Connecting to vRA...")
-	$vra = [vRAAPI]::new($configVra.getConfigValue($targetEnv, "infra", "server"), 
+	$vra = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")),
 						 $targetTenant, 
-						 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "user"), 
-						 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "password"))
+						 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "user")),
+						 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "password")))
 
 	# Création d'une connexion au serveur NSX pour accéder aux API REST de NSX
 	$logHistory.addLineAndDisplay("Connecting to NSX-T...")
-	$nsx = [NSXAPI]::new($configNSX.getConfigValue($targetEnv, "server"), $configNSX.getConfigValue($targetEnv, "user"), $configNSX.getConfigValue($targetEnv, "password"))
+	$nsx = [NSXAPI]::new($configNSX.getConfigValue(@($targetEnv, "server")), 
+						 $configNSX.getConfigValue(@($targetEnv, "user")), 
+						 $configNSX.getConfigValue(@($targetEnv, "password")))
 
 	$doneBGList = @()
 
@@ -1442,7 +1444,7 @@ try
 	$aMomentInThePast = (Get-Date).AddDays(-$global:AD_GROUP_MODIFIED_LAST_X_DAYS)
 
 	# Ajout de l'adresse par défaut à laquelle envoyer les mails. 
-	$capacityAlertMails = @($configGlobal.getConfigValue("mail", "capacityAlert"))
+	$capacityAlertMails = @($configGlobal.getConfigValue(@("mail", "capacityAlert")))
 
 	# Parcours des groupes AD pour l'environnement/tenant donné
 	$adGroupList | ForEach-Object {

--- a/powershell/vsphere-update-vm-notes.ps1
+++ b/powershell/vsphere-update-vm-notes.ps1
@@ -119,7 +119,7 @@ try
 	$valToReplace = @{
 		targetEnv = $targetEnv
 	}
-	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MAIL_TEMPLATE_FOLDER, `
+	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, `
 												($global:VRA_MAIL_SUBJECT_PREFIX_NO_TENANT -f $targetEnv), $valToReplace)
 
 	# Création d'un objet pour gérer les compteurs (celui-ci sera accédé en variable globale même si c'est pas propre XD)
@@ -140,10 +140,10 @@ try
 
     # Connexion au serveur vSphere
 
-    $credSecurePwd = $configVSphere.getConfigValue($targetEnv, "password") | ConvertTo-SecureString -AsPlainText -Force
-    $credObject = New-Object System.Management.Automation.PSCredential -ArgumentList $configVSphere.getConfigValue($targetEnv, "user"), $credSecurePwd	
+    $credSecurePwd = $configVSphere.getConfigValue(@($targetEnv, "password")) | ConvertTo-SecureString -AsPlainText -Force
+    $credObject = New-Object System.Management.Automation.PSCredential -ArgumentList $configVSphere.getConfigValue(@($targetEnv, "user")), $credSecurePwd	
             
-    $connectedvCenter = Connect-VIServer -Server $configVSphere.getConfigValue($targetEnv, "server") -Credential $credObject
+    $connectedvCenter = Connect-VIServer -Server $configVSphere.getConfigValue(@($targetEnv, "server")) -Credential $credObject
 
     $logHistory.addLineAndDisplay("Getting VMs...")
 

--- a/powershell/xaas-backup-endpoint.ps1
+++ b/powershell/xaas-backup-endpoint.ps1
@@ -123,7 +123,7 @@ try
 		targetEnv = $targetEnv
 		targetTenant = $targetTenant
 	}
-	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MAIL_TEMPLATE_FOLDER, `
+	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, `
 												($global:VRA_MAIL_SUBJECT_PREFIX -f $targetEnv, $targetTenant), $valToReplace)
 
     # -------------------------------------------------------------------------------------------
@@ -138,9 +138,9 @@ try
         { ($_ -eq $ACTION_GET_BACKUP_TAG) -or ($_ -eq $ACTION_SET_BACKUP_TAG) }  {
             <# Connexion à l'API Rest de vSphere. On a besoin de cette connxion aussi (en plus de celle du dessus) parce que les opérations sur les tags ne fonctionnent
                 pas via les CMDLet Get-TagAssignement et autre...  #>
-            $vsphereApi = [vSphereAPI]::new($configXaaSBackup.getConfigValue($targetEnv, "vSphere", "server"), 
-            $configXaaSBackup.getConfigValue($targetEnv, "vSphere", "user"), 
-            $configXaaSBackup.getConfigValue($targetEnv, "vSphere", "password"))
+            $vsphereApi = [vSphereAPI]::new($configXaaSBackup.getConfigValue(@($targetEnv, "vSphere", "server")),
+            $configXaaSBackup.getConfigValue(@($targetEnv, "vSphere", "user")),
+            $configXaaSBackup.getConfigValue(@($targetEnv, "vSphere", "password")))
 
             # Si on doit activer le Debug,
             if(Test-Path (Join-Path $PSScriptRoot "$($MyInvocation.MyCommand.Name).debug"))
@@ -152,9 +152,9 @@ try
 
         { ($_ -eq $ACTION_GET_BACKUP_LIST) -or ($_ -eq $ACTION_RESTORE_BACKUP) -or ($_ -eq $ACTION_GET_RESTORE_STATUS)} {
             # Connexion à l'API REST de NetBackup
-            $nbu = [NetBackupAPI]::new($configXaaSBackup.getConfigValue($targetEnv, "backup", "server"), 
-            $configXaaSBackup.getConfigValue($targetEnv, "backup", "user"), 
-            $configXaaSBackup.getConfigValue($targetEnv, "backup", "password"))   
+            $nbu = [NetBackupAPI]::new($configXaaSBackup.getConfigValue(@($targetEnv, "backup", "server")),
+                                        $configXaaSBackup.getConfigValue(@($targetEnv, "backup", "user")),
+                                        $configXaaSBackup.getConfigValue(@($targetEnv, "backup", "password")))
 
             # Si on doit activer le Debug,
             if(Test-Path (Join-Path $PSScriptRoot "$($MyInvocation.MyCommand.Name).debug"))
@@ -166,10 +166,10 @@ try
 
         $ACTION_VM_HAS_RUNNING_SNAPSHOT {
             # Création d'une connexion au serveur vRA pour accéder à ses API REST
-            $vra = [vRAAPI]::new($configVra.getConfigValue($targetEnv, "infra", "server"), 
+            $vra = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")),
                                 $targetTenant, 
-                                $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "user"), 
-                                $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "password"))
+                                $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "user")),
+                                $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "password")))
         
             # Si on doit activer le Debug,
             if(Test-Path (Join-Path $PSScriptRoot "$($MyInvocation.MyCommand.Name).debug"))

--- a/powershell/xaas-backup-sync-vm-tags.ps1
+++ b/powershell/xaas-backup-sync-vm-tags.ps1
@@ -111,7 +111,7 @@ try
 		targetEnv = $targetEnv
 		targetTenant = $targetTenant
 	}
-	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MAIL_TEMPLATE_FOLDER, `
+	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, `
 												($global:VRA_MAIL_SUBJECT_PREFIX -f $targetEnv, $targetTenant), $valToReplace)
 
     # -------------------------------------------------------------------------------------------
@@ -122,16 +122,16 @@ try
     <# Connexion à l'API Rest de vSphere. On a besoin de cette connxion aussi (en plus de celle du dessus) parce que les opérations sur les tags ne fonctionnent
     pas via les CMDLet Get-TagAssignement et autre...  #>
     $logHistory.addLineAndDisplay("Connecting to vSphere...")
-    $vsphereApi = [vSphereAPI]::new($configXaaSBackup.getConfigValue($targetEnv, "vSphere", "server"), 
-                                    $configXaaSBackup.getConfigValue($targetEnv, "vSphere", "user"), 
-                                    $configXaaSBackup.getConfigValue($targetEnv, "vSphere", "password"))
+    $vsphereApi = [vSphereAPI]::new($configXaaSBackup.getConfigValue(@($targetEnv, "vSphere", "server")),
+                                    $configXaaSBackup.getConfigValue(@($targetEnv, "vSphere", "user")),
+                                    $configXaaSBackup.getConfigValue(@($targetEnv, "vSphere", "password")))
 
     # Création d'une connexion au serveur vRA pour accéder à ses API REST
 	$logHistory.addLineAndDisplay("Connecting to vRA...")
-	$vra = [vRAAPI]::new($configVra.getConfigValue($targetEnv, "infra", "server"), 
+	$vra = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")),
 						 $targetTenant, 
-						 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "user"), 
-						 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "password"))
+						 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "user")),
+						 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "password")))
 
     if($importFromvSphere)                         
     {

--- a/powershell/xaas-billing.ps1
+++ b/powershell/xaas-billing.ps1
@@ -242,7 +242,7 @@ try
 	$valToReplace = @{
 		targetEnv = $targetEnv
 	}
-	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MAIL_TEMPLATE_FOLDER, `
+	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, `
 												($global:VRA_MAIL_SUBJECT_PREFIX_NO_TENANT -f $targetEnv), $valToReplace)
 
     # Création d'un objet pour gérer les compteurs (celui-ci sera accédé en variable globale même si c'est pas propre XD)
@@ -262,12 +262,12 @@ try
     }
 
     # Pour accéder à la base de données
-	$sqldb = [SQLDB]::new([DBType]::MSSQL, `
-                        $configVra.getConfigValue($targetEnv, "db", "host"), `
-                        $configVra.getConfigValue($targetEnv, "db", "dbName"), `
-                        $configVra.getConfigValue($targetEnv, "db", "user"), `
-                        $configVra.getConfigValue($targetEnv, "db", "password"), `
-                        $configVra.getConfigValue($targetEnv, "db", "port"))
+	$sqldb = [SQLDB]::new([DBType]::MSSQL,
+                        $configVra.getConfigValue(@($targetEnv, "db", "host")),
+                        $configVra.getConfigValue(@($targetEnv, "db", "dbName")),
+                        $configVra.getConfigValue(@($targetEnv, "db", "user")),
+                        $configVra.getConfigValue(@($targetEnv, "db", "password")),
+                        $configVra.getConfigValue(@($targetEnv, "db", "port")))
 
     $vraTenantList = @{}
 
@@ -276,10 +276,10 @@ try
     {
         # Création d'une connexion au serveur vRA pour accéder à ses API REST
         $logHistory.addLineAndDisplay(("Connecting to vRA tenant {0}...") -f $tenant)
-        $vraTenantList.$tenant = [vRAAPI]::new($configVra.getConfigValue($targetEnv, "infra", "server"), 
+        $vraTenantList.$tenant = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")),
                                             $tenant, 
-                                            $configVra.getConfigValue($targetEnv, "infra", $tenant, "user"), 
-                                            $configVra.getConfigValue($targetEnv, "infra", $tenant, "password"))
+                                            $configVra.getConfigValue(@($targetEnv, "infra", $tenant, "user")),
+                                            $configVra.getConfigValue(@($targetEnv, "infra", $tenant, "password")))
     }
 
 
@@ -301,9 +301,9 @@ try
     Invoke-expression $expression
 
     # Pour accéder à Copernic
-    $copernic = [CopernicAPI]::new($configBilling.getConfigValue($targetEnv, "copernic", "server"), `
-                                   $configBilling.getConfigValue($targetEnv, "copernic", "username"), `
-                                   $configBilling.getConfigValue($targetEnv, "copernic", "password"))
+    $copernic = [CopernicAPI]::new($configBilling.getConfigValue(@($targetEnv, "copernic", "server")),
+                                   $configBilling.getConfigValue(@($targetEnv, "copernic", "username")),
+                                   $configBilling.getConfigValue(@($targetEnv, "copernic", "password")))
 
     # En fonction de l'action demandée
     switch($action)

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -499,15 +499,15 @@ try
     $nameGeneratorNAS = [NameGeneratorNAS]::new($targetEnv, $targetTenant)
 
     # Création d'une connexion au serveur vRA pour accéder à ses API REST
-	$vra = [vRAAPI]::new($configVra.getConfigValue($targetEnv, "infra", "server"), 
+	$vra = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")), 
 						 $targetTenant, 
-						 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "user"), 
-						 $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "password"))
+						 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "user")),
+						 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "password")))
 
     # Création de l'objet pour se connecter aux clusters NetApp
-    $netapp = [NetAppAPI]::new($configNAS.getConfigValue($targetEnv, "serverList"), `
-                                $configNAS.getConfigValue($targetEnv, "user"), `
-                                $configNAS.getConfigValue($targetEnv, "password"))
+    $netapp = [NetAppAPI]::new($configNAS.getConfigValue(@($targetEnv, "serverList")),
+                                $configNAS.getConfigValue(@($targetEnv, "user")),
+                                $configNAS.getConfigValue(@($targetEnv, "password")))
 
     # Si on doit activer le Debug,
     if(Test-Path (Join-Path $PSScriptRoot "$($MyInvocation.MyCommand.Name).debug"))
@@ -522,7 +522,7 @@ try
 		targetEnv = $targetEnv
 		targetTenant = $targetTenant
     }
-    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MAIL_TEMPLATE_FOLDER, `
+    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, `
                                                     ($global:VRA_MAIL_SUBJECT_PREFIX -f $targetEnv, $targetTenant), $valToReplace)
 
     # Si on nous a passé un ID de BG,
@@ -714,8 +714,8 @@ try
                                 d'accéder au share réseau. Donc, pour palier à ceci, on fait les choses d'une manière différente. On récupère les credentials de
                                 l'utilisateur et on monte un lecteur réseau temporaire pour pouvoir utiliser celui-ci pour mettre à jour les ACLs.
                              #>
-                            $secPassword = ConvertTo-SecureString $configNAS.getConfigValue("psGateway", "password") -AsPlainText -Force
-                            $credentials = New-Object System.Management.Automation.PSCredential($configNAS.getConfigValue("psGateway", "user"), $secPassword)
+                            $secPassword = ConvertTo-SecureString $configNAS.getConfigValue(@("psGateway", "password")) -AsPlainText -Force
+                            $credentials = New-Object System.Management.Automation.PSCredential($configNAS.getConfigValue(@("psGateway", "user")), $secPassword)
                             
                             $logHistory.addLine(("Mounting '{0}' on '{1}'..." -f $result.mountPath, $global:XAAS_NAS_TEMPORARY_DRIVE))
                             # On démonte le dossier monté dans le cas hypothétique où il serait déjà utilisé 

--- a/powershell/xaas-nas-sync-webdav.ps1
+++ b/powershell/xaas-nas-sync-webdav.ps1
@@ -425,7 +425,7 @@ try
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))
 
-    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:NAS_MAIL_TEMPLATE_FOLDER, `
+    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:NAS_MAIL_TEMPLATE_FOLDER, `
                                                 $global:NAS_MAIL_SUBJECT_PREFIX , $valToReplace)
 
     # Contrôle que l'utilisateur pour exécuter le script soit correct
@@ -451,15 +451,15 @@ try
     # $counters.add('VMNotInvSphere', '# VM not in vSphere')
 
     # Création d'une connexion au serveur vRA pour accéder à ses API REST
-	$vra = [vRAAPI]::new($configVra.getConfigValue($targetEnv, "infra", "server"), 
+	$vra = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")),
                         $targetTenant, 
-                        $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "user"), 
-                        $configVra.getConfigValue($targetEnv, "infra", $targetTenant, "password"))
+                        $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "user")),
+                        $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "password")))
 
     # Création de l'objet pour se connecter aux clusters NetApp
-    $netapp = [NetAppAPI]::new($configNAS.getConfigValue($targetEnv, "serverList"), `
-                                $configNAS.getConfigValue($targetEnv, "user"), `
-                                $configNAS.getConfigValue($targetEnv, "password"))
+    $netapp = [NetAppAPI]::new($configNAS.getConfigValue(@($targetEnv, "serverList")),
+                                $configNAS.getConfigValue(@($targetEnv, "user")),
+                                $configNAS.getConfigValue(@($targetEnv, "password")))
 
             
     # Objet pour pouvoir envoyer des mails de notification

--- a/powershell/xaas-s3-endpoint.ps1
+++ b/powershell/xaas-s3-endpoint.ps1
@@ -260,11 +260,11 @@ try
     $targetTenant = $targetTenant.ToLower()
 
     # Création de l'objet pour communiquer avec Scality
-    $scality = [ScalityAPI]::new($configXaaSS3.getConfigValue($targetEnv, "server"), 
-                                 $configXaaSS3.getConfigValue($targetEnv, $targetTenant, "credentialProfile"), 
-                                 $configXaaSS3.getConfigValue($targetEnv, $targetTenant, "webConsoleUser"), 
-                                 $configXaaSS3.getConfigValue($targetEnv, $targetTenant, "webConsolePassword"),
-                                 $configXaaSS3.getConfigValue($targetEnv, "isScality"))
+    $scality = [ScalityAPI]::new($configXaaSS3.getConfigValue(@($targetEnv, "server")),
+                                 $configXaaSS3.getConfigValue(@($targetEnv, $targetTenant, "credentialProfile")),
+                                 $configXaaSS3.getConfigValue(@($targetEnv, $targetTenant, "webConsoleUser")),
+                                 $configXaaSS3.getConfigValue(@($targetEnv, $targetTenant, "webConsolePassword")),
+                                 $configXaaSS3.getConfigValue(@($targetEnv, "isScality")))
 
     # Si on doit activer le Debug,
     if(Test-Path (Join-Path $PSScriptRoot "$($MyInvocation.MyCommand.Name).debug"))
@@ -279,7 +279,7 @@ try
 		targetEnv = $targetEnv
 		targetTenant = $targetTenant
 	}
-	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MAIL_TEMPLATE_FOLDER, `
+	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, `
 												($global:VRA_MAIL_SUBJECT_PREFIX -f $targetEnv, $targetTenant), $valToReplace)
 
 
@@ -304,7 +304,7 @@ try
             $nameGeneratorS3 = [NameGeneratorS3]::new($unitOrSvcID,  $friendlyName)
 
             $bucketInfos.bucketName = $nameGeneratorS3.getBucketName()
-            $bucketInfos.serverName = $configXaaSS3.getConfigValue($targetEnv, "server")
+            $bucketInfos.serverName = $configXaaSS3.getConfigValue(@($targetEnv, "server"))
 
             $logHistory.addLine("Creating bucket {0}..." -f $bucketInfos.bucketName)
 


### PR DESCRIPTION
Changement de la manière d'accéder aux valeurs dans les fichiers de configuration. Avant on avait plusieurs fonctions avec un nombre de paramètres différents en fonction du niveau auquel se trouvait l'information recherchée. Maintenant, on utilise un seul et unique paramètre (ce qui fait donc une seule et unique fonction) qui est un tableau avec le chemin jusqu'à la valeur recherchée.

## Reste à faire
- [x] Attendre le retour d'Eric concernant le script `iaas/IaaS-Template-Sync-sites.ps1` pour savoir s'il a pu récupérer la bonne version sur la passerelle PowerShell
- [x] Récupération du fichier `iaas/IaaS-Template-Sync-sites.ps1` dans la branche courante (`config-reader`)
- [x] Mettre à jour le script `iaas/IaaS-Template-Sync-sites.ps1` avec la nouvelle manière d'accéder aux valeurs de configuration