### PR TITLE
MyNAS fixes

### DIFF
--- a/powershell/mynas-process-hd-actions-requests.ps1
+++ b/powershell/mynas-process-hd-actions-requests.ps1
@@ -102,7 +102,7 @@ try
    $logHistory = [LogHistory]::new('mynas-process-hd-actions', (Join-Path $PSScriptRoot "logs"), 30)
 
    # Objet pour pouvoir envoyer des mails de notification
-   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
+   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
 
    $nameGeneratorMyNAS = [NameGeneratorMyNAS]::new()
 

--- a/powershell/mynas-process-infos-from-cadi.ps1
+++ b/powershell/mynas-process-infos-from-cadi.ps1
@@ -86,7 +86,7 @@ try
    $logHistory = [LogHistory]::new('mynas-process-info-from-cadi', (Join-Path $PSScriptRoot "logs"), 30)
 
    # Objet pour pouvoir envoyer des mails de notification
-   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
+   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
    
    $nameGeneratorMyNAS = [NameGeneratorMyNAS]::new()
 
@@ -95,11 +95,11 @@ try
 
    # Création de l'objet pour faire les requêtes dans CADI
    $mysql_cadi = [SQLDB]::new([DBType]::MySQL, `
-                              $configMyNAS.getConfigValue("cadi", "host"), `
-                              $configMyNAS.getConfigValue("cadi", "db"), `
-                              $configMyNAS.getConfigValue("cadi", "user"), `
-                              $configMyNAS.getConfigValue("cadi", "password"), `
-                              $configMyNAS.getConfigValue("cadi", "port"))                           
+                              $configMyNAS.getConfigValue(@("cadi", "host")),
+                              $configMyNAS.getConfigValue(@("cadi", "db")),
+                              $configMyNAS.getConfigValue(@("cadi", "user")),
+                              $configMyNAS.getConfigValue(@("cadi", "password")),
+                              $configMyNAS.getConfigValue(@("cadi", "port")))
 
    # Création du dossier si n'existe pas
    if(!(Test-path $global:FILES_TO_PUSH_FOLDER))

--- a/powershell/mynas-process-user-delete-requests.ps1
+++ b/powershell/mynas-process-user-delete-requests.ps1
@@ -91,20 +91,20 @@ try
    $logHistory = [LogHistory]::new('mynas-process-user-delete', (Join-Path $PSScriptRoot "logs"), 30)
 
    # Objet pour pouvoir envoyer des mails de notification
-   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
+   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
    
    # Création de l'objet pour se connecter aux clusters NetApp
-   $netapp = [NetAppAPI]::new($configMyNAS.getConfigValue("nas", "serverList"), `
-                              $configMyNAS.getConfigValue("nas", "user"), `
-                              $configMyNAS.getConfigValue("nas", "password"))
+   $netapp = [NetAppAPI]::new($configMyNAS.getConfigValue(@("nas", "serverList")),
+                              $configMyNAS.getConfigValue(@("nas", "user")),
+                              $configMyNAS.getConfigValue(@("nas", "password")))
 
    # Chargement du module (si nécessaire)
    loadDataOnTapModule 
 
    # Génération du mot de passe pour plus tard
-   $secPassword = ConvertTo-SecureString $configMyNAS.getConfigValue("nas", "password") -AsPlainText -Force
+   $secPassword = ConvertTo-SecureString $configMyNAS.getConfigValue(@("nas", "password")) -AsPlainText -Force
    # Création des credentials pour l'utilisateur
-   $credentials = New-Object System.Management.Automation.PSCredential($configMyNAS.getConfigValue("nas", "user"), $secPassword)
+   $credentials = New-Object System.Management.Automation.PSCredential($configMyNAS.getConfigValue(@("nas", "user")), $secPassword)
 
 
    $logHistory.addLineAndDisplay("Getting infos... ")

--- a/powershell/mynas-process-user-rename-requests.ps1
+++ b/powershell/mynas-process-user-rename-requests.ps1
@@ -184,12 +184,12 @@ try
    $logHistory = [LogHistory]::new('mynas-process-username-rename', (Join-Path $PSScriptRoot "logs"), 30)
     
    # Objet pour pouvoir envoyer des mails de notification
-   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
+   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
    
    # Création de l'objet pour se connecter aux clusters NetApp
-   $netapp = [NetAppAPI]::new($configMyNAS.getConfigValue("nas", "serverList"), `
-                              $configMyNAS.getConfigValue("nas", "user"), `
-                              $configMyNAS.getConfigValue("nas", "password"))
+   $netapp = [NetAppAPI]::new($configMyNAS.getConfigValue(@("nas", "serverList")),
+                              $configMyNAS.getConfigValue(@("nas", "user")),
+                              $configMyNAS.getConfigValue(@("nas", "password")))
 
    $nameGeneratorMyNAS = [NameGeneratorMyNAS]::new()
    

--- a/powershell/mynas-process-waiting-quota-update-requests.ps1
+++ b/powershell/mynas-process-waiting-quota-update-requests.ps1
@@ -181,6 +181,17 @@ try
    foreach($updateInfos in $quotaUpdateList)
    {
       
+      # On commence par regarder si l'utilisateur existe dans AD
+      try
+      {
+         Get-ADUser $updateInfos.username | Out-Null
+      }
+      catch
+      {
+         $logHistory.addWarningAndDisplay(("User {0} doesn't exists in ActiveDirectory, skipping it" -f $updateInfos.username))
+         continue
+      }
+
       # Génréation des informations 
       $usernameAndDomain="INTRANET\"+$updateInfos.username
       

--- a/powershell/mynas-process-waiting-quota-update-requests.ps1
+++ b/powershell/mynas-process-waiting-quota-update-requests.ps1
@@ -249,7 +249,7 @@ try
       }
       else # Le quota est correct
       {
-         $logHistory.addLineAndDisplay(( "-> Quota is correct ({0} MB), no change needed" -f $currentQuota ))
+         $logHistory.addLineAndDisplay(( "-> Quota is correct ({0} MB), no change needed" -f $currentQuota.space.hard_limit ))
       }
 
    }# FIN BOUCLE de parcours des quotas à modifier

--- a/powershell/mynas-process-waiting-quota-update-requests.ps1
+++ b/powershell/mynas-process-waiting-quota-update-requests.ps1
@@ -144,7 +144,7 @@ try
    $logHistory = [LogHistory]::new('mynas-process-quota-update', (Join-Path $PSScriptRoot "logs"), 30)
     
    # Objet pour pouvoir envoyer des mails de notification
-   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
+   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
 
    <# Pour enregistrer des notifications à faire par email. Celles-ci peuvent être informatives ou des erreurs à remonter
 	aux administrateurs du service
@@ -160,9 +160,9 @@ try
    }
 
    # Création de l'objet pour se connecter aux clusters NetApp
-   $netapp = [NetAppAPI]::new($configMyNAS.getConfigValue("nas", "serverList"), `
-                              $configMyNAS.getConfigValue("nas", "user"), `
-                              $configMyNAS.getConfigValue("nas", "password"))
+   $netapp = [NetAppAPI]::new($configMyNAS.getConfigValue(@("nas", "serverList")),
+                              $configMyNAS.getConfigValue(@("nas", "user")),
+                              $configMyNAS.getConfigValue(@("nas", "password")))
 
    # le format des lignes renvoyées est le suivant :
    # <volumeName>,<usernameShort>,<vServerName>,<Sciper>,<softQuotaKB>,<hardQuotaKB>

--- a/powershell/mynas-www-push-user-quota-usage.ps1
+++ b/powershell/mynas-www-push-user-quota-usage.ps1
@@ -160,14 +160,14 @@ try
    $logHistory = [LogHistory]::new('mynas-push-user-quota-usage', (Join-Path $PSScriptRoot "logs"), 30)
 
    # Objet pour pouvoir envoyer des mails de notification
-   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue("mail", "admin"), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
+   $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})
    
    $nameGeneratorMyNAS = [NameGeneratorMyNAS]::new()
 
    # Création de l'objet pour se connecter aux clusters NetApp
-   $netapp = [NetAppAPI]::new($configMyNAS.getConfigValue("nas", "serverList"), `
-                              $configMyNAS.getConfigValue("nas", "user"), `
-                              $configMyNAS.getConfigValue("nas", "password"))
+   $netapp = [NetAppAPI]::new($configMyNAS.getConfigValue(@("nas", "serverList")),
+                              $configMyNAS.getConfigValue(@("nas", "user")),
+                              $configMyNAS.getConfigValue(@("nas", "password")))
 
 
    # Chargement du module (si nécessaire)

--- a/powershell/resources/mail-templates/MyNAS/quota-update-users-not-in-ad.html
+++ b/powershell/resources/mail-templates/MyNAS/quota-update-users-not-in-ad.html
@@ -1,0 +1,7 @@
+Les utilisateurs suivant n'ont pas été trouvés dans ActiveDirectory, la demande de modification/création de quota associée n'a donc pas pu être traitée.<br>
+Il s'agit probablement cas particulier dans le cycle de vie de l'utilisateur, il n'y a pas spécialement raison de s'inquiéter. <br>
+Les demandes de modification/création de quota des utilisateurs ci-dessous ont été notées comme "traitées" donc leur nom ne devrait plus réapparaître dans un mail de ce type.
+<br>
+<ul>
+    <li>{{userList}}</li>
+</ul>


### PR DESCRIPTION
- Adaptation du code suite aux modifications faite dans #175 
- Ajout d'un check dans la création/mise à jour des quotas utilisateur. On contrôle maintenant si l'utilisateur a effectivement un compte dans AD. On peut en effet tomber sur cas particulier ou on s'est marché sur le sachet quelque part et il y a besoin de faire une mise à jour de quota pour un utilisateur qui a été effacé entre temps.
- Ajout de compteurs + une notification pour la mise à jour des quotas
- Correction d'un petit bug dans l'affichage d'un message dans la console.