### PR TITLE
Refactor to avoid incorrect notification mails with warnings

### DIFF
--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -615,19 +615,19 @@ function prepareAddMissingBGEntPublicServices
 		# Parcours et ajout
 		$mandatoryItems | ForEach-Object {
 
-			$catalogItem = $vra.getCatalogItem($_.name)
+			# On regarde si on peut bien ajouter l'élément de catalogue pour le BG courant
+			if(($_.onlyForBG.count -eq 0) -or `
+				(($_.onlyForBG.count -gt 0) -and ($_.onlyForBG -contains $bgName)))
+			{
+				$catalogItem = $vra.getCatalogItem($_.name)
 
-			# Elément de catalogue pas trouvé dans vRA
-			if($null -eq $catalogItem)
-			{
-				$logHistory.addWarningAndDisplay(("--> Catalog item '{0}' not found!" -f $_.name))
-				$notifications.mandatoryItemsNotFound += $_.name
-			}
-			else # L'élément de catalogue existe
-			{
-				# On regarde si on peut bien ajouter l'élément de catalogue pour le BG courant
-				if(($_.onlyForBG.count -eq 0) -or `
-					(($_.onlyForBG.count -gt 0) -and ($_.onlyForBG -contains $bgName)))
+				# Elément de catalogue pas trouvé dans vRA
+				if($null -eq $catalogItem)
+				{
+					$logHistory.addWarningAndDisplay(("--> Catalog item '{0}' not found!" -f $_.name))
+					$notifications.mandatoryItemsNotFound += $_.name
+				}
+				else # L'élément de catalogue existe
 				{
 					$logHistory.addLineAndDisplay(("--> Adding catalog item '{0}'..." -f $_.name))
 
@@ -642,14 +642,13 @@ function prepareAddMissingBGEntPublicServices
 					}
 					
 					$ent = $vra.prepareAddEntCatalogItem($ent, $catalogItem, $itemApprovalPolicy)
+				}
 
-				}
-				else # L'élément de catalogue n'est pas autorisé pour le BG courant
-				{
-					$logHistory.addWarningAndDisplay(("--> Catalog item '{0}' not allowed for BG '{1}'" -f $_.name, $bgName))
-				}
-				
-			}# FIN SI l'élément de catalogue existe
+			}
+			else # L'élément de catalogue n'est pas autorisé pour le BG courant
+			{
+				$logHistory.addWarningAndDisplay(("--> Catalog item '{0}' not allowed for BG '{1}'" -f $_.name, $bgName))
+			}
 			
 		}# FIN BOUCLE de parcours des éléments de catalogue obligatoires
 


### PR DESCRIPTION
Suite à la PR #180 , une petite erreur insignifiante (si si) c'était glissée. En fait, on testait la présence d'un élément de catalogue à ajouter en tant que "entitled item" sans avoir regardé avant s'il fallait effectivement l'ajouter. Ceci posait donc problème pour le tenant EPFL lorsque l'on contrôlait les éléments `Linux-Debug` ou `SAP_Application_Clone` qui ne sont disponibles que pour le tenant ITServices.
Conséquence: un mail de "warning" était envoyé aux admins pour dire que ces éléments de catalogue n'avaient pas été trouvés alors que finalement, c'était normal.
L'ordre de l'exécution des différents contrôles a été changé afin d'éviter ceci.