### PR TITLE
Remove old unit names

### DIFF
--- a/powershell/data/billing/ge-unit-mapping.json
+++ b/powershell/data/billing/ge-unit-mapping.json
@@ -79,19 +79,6 @@
         "level3Center": "SV-SG",
         "level4GeUnit": "SV-GE"
     },
-    /* A supprimer mi-février 2021 environ */
-    {
-        "level3Center": "SI-VP",
-        "level4GeUnit": "VPSI"
-    },
-    {
-        "level3Center": "RH-RH",
-        "level4GeUnit": "RH-G"
-    },
-    {
-        "level3Center": "RHO-VP",
-        "level4GeUnit": "VPRHO"
-    },
     /* Nouveaux noms depuis début février 2021 */
     {
         "level3Center": "DSI",


### PR DESCRIPTION
Suite à #193 qui ajoutait le nécessaire pour le passage de VPSI vers DSI, cette PR s'occupe de nettoyer les anciens noms qui ne seront donc plus utilisés.