### PR TITLE
Change mail encoding

### DIFF
--- a/powershell/include/NotificationMail.inc.ps1
+++ b/powershell/include/NotificationMail.inc.ps1
@@ -153,7 +153,7 @@ class NotificationMail
         Remove-Item $tmpMailFile -Force
 
         Send-MailMessage -From ("noreply+{0}" -f $this.sendToAddress) -To $this.sendToAddress -Subject $mailSubject `
-                        -Body $mailMessage -BodyAsHtml:$true -SmtpServer "mail.epfl.ch" -Encoding Unicode
+                        -Body $mailMessage -BodyAsHtml:$true -SmtpServer "mail.epfl.ch" -Encoding:UTF8
     }
 
 

--- a/powershell/include/billing/Billing.inc.ps1
+++ b/powershell/include/billing/Billing.inc.ps1
@@ -331,7 +331,7 @@ class Billing
         }
         
         Send-MailMessage -From "noreply+vra.billing.bot@epfl.ch" -To $toMail -Subject $mailSubject `
-                        -Body $mailMessage -BodyAsHtml:$true -SmtpServer "mail.epfl.ch" -Encoding Unicode -Attachments $PDFBillFile    
+                        -Body $mailMessage -BodyAsHtml:$true -SmtpServer "mail.epfl.ch" -Encoding:UTF8 -Attachments $PDFBillFile    
     }
 
 


### PR DESCRIPTION
Suite à l'envoi de certaines facture par email, il a été signalé via un incident (INC0394553) qu'il y avait un problème au niveau de l'encodage du contenu du mail. Lorsqu'on envoyait le mail, on précisait `-Encoding Unicode` et ceci était transformé en `"charset: utf-16"` dans le header du mail.. oui parce que dans Framework .NET, le `Unicode`, c'est du `UTF-16` pour lui... 🤦 
Et pour une raison inconnue, dans Microsoft Outlook, le message s'affiche correctement, mais pas dans des applications tierces comme Thunderbird (semblerait-il)... 
Donc, correction pour faire en sorte de "forcer" l'utilisation de `UTF-8` dans l'envoi du mail avec PowerShell.