### PR TITLE
New struct fix (CHG0040029)

### DIFF
--- a/powershell/config/LDAP.json
+++ b/powershell/config/LDAP.json
@@ -11,6 +11,8 @@
                     /* Anciennement RHO */
                     "VPO", 
                     "VPO-RH", 
+                    "VPO-SE",
+                    "VPO-DC",
                     /* Anciennement ENT-R et ENT-E */
                     "VPA-AVP-CP",
                     /* Anciennement E */ 

--- a/powershell/config/LDAP.json
+++ b/powershell/config/LDAP.json
@@ -5,11 +5,25 @@
             {
                 "rootDN": "o=epfl,c=ch",
                 "nbLevelsForSearch": 3,
-                "limitToFaculties": [ "SV", "SI", "P", "STI", "ENAC", "IC", "SB", "CDM", "CDH", "E", "ENT-E", "R", "RHO", "ENT-R", "ENT-P", "VPO-SI", "VPO"]
+                "limitToFaculties": [ "SV", "SI", "P", "STI", "ENAC", "IC", "SB", "CDM", "CDH", "E", "ENT-E", "R", "RHO", "ENT-R", "ENT-P", 
+                    /* Anciennement SI */    
+                    "VPO-SI", 
+                    /* Anciennement RHO */
+                    "VPO", 
+                    "VPO-RH", 
+                    /* Anciennement ENT-R et ENT-E */
+                    "VPA-AVP-CP",
+                    /* Anciennement E */ 
+                    "VPA-AVP-E", 
+                    "VPA-AVP-PGE",
+                    /* Anciennement R */
+                    "VPA",
+                    "VPA-AVP-R"                    
+                ]
             },
             {
                 "rootDN": "o=ehe,c=ch",
-                "nbLevelsForSearch": 2,
+                "nbLevelsForSearch": 3,
                 "limitToFaculties": [ ]
             }
         ]

--- a/powershell/data/billing/ge-unit-mapping.json
+++ b/powershell/data/billing/ge-unit-mapping.json
@@ -104,5 +104,23 @@
     {
         "level3Center": "DVPO",
         "level4GeUnit": "EM-GE"
+    },
+    {
+        "level3Center": "AVP-CP-AVP",
+        "level4GeUnit": "AVP-CP-GE"
+    },
+    {
+        "level3Center": "AVP-E-AVP",
+        "level4GeUnit": "VPA-AVP-E-GE"
+    },
+    {
+        "level3Center": "AVP-PGE-AVP",
+        "level4GeUnit": "AVP-PGE-GE"
+    },
+    {
+        "level3Center": "AVP-R-AVP",
+        "level4GeUnit": "AVP-R-GE"
     }
+
+    
 ]

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -369,6 +369,13 @@ function createOrUpdateBG
 			$bg = $vra.updateBG($bg, $bgName, $bgDesc, $machinePrefixId, @{"$global:VRA_CUSTOM_PROP_EPFL_BILLING_FINANCE_CENTER" = $financeCenter})
 		}
 
+		# Si le nom du BG n'est pas à jour (il peut y avoir une dérive)
+		if((getBGCustomPropValue -bg $bg -customPropName $global:VRA_CUSTOM_PROP_VRA_BG_NAME) -ne $bgName)
+		{
+			# Mise à jour
+			$bg = $vra.updateBG($bg, $bgName, $bgDesc, $machinePrefixId, @{"$global:VRA_CUSTOM_PROP_VRA_BG_NAME" = $bgName})
+		}
+
 		# Si le BG n'a pas la custom property donnée, on l'ajoute
 		# FIXME: Cette partie de code pourra être enlevée au bout d'un moment car elle est juste prévue pour mettre à jours
 		# les BG existants avec la nouvelle "Custom Property"
@@ -399,6 +406,7 @@ function createOrUpdateBG
 			# S'il y a eu changement de nom,
 			if($bg.name -ne $bgName)
 			{
+				$logHistory.addLineAndDisplay(("-> Renaming BG '{0}' to '{1}'" -f $bg.name, $bgName))
 				# Recherche du nom actuel du dossier où se trouvent les ISO du BG
 				$bgISOFolderCurrent = $nameGenerator.getNASPrivateISOPath($bg.name)
 				# Recherche du nouveau nom du dossier où devront se trouver les ISO
@@ -431,6 +439,8 @@ function createOrUpdateBG
 				
 				# Mise à jour de la custom property qui contient le nom du BG
 				$bg = $vra.updateBG($bg, $bgName, $bgDesc, $machinePrefixId, @{"$global:VRA_CUSTOM_PROP_VRA_BG_NAME" = $bgName})
+
+				$counters.inc('BGRenamed')
 				
 			}# Fin s'il y a eu changement de nom 
 
@@ -440,6 +450,13 @@ function createOrUpdateBG
 			$bg = $vra.updateBG($bg, $bgName, $bgDesc, $machinePrefixId, @{"$global:VRA_CUSTOM_PROP_VRA_BG_STATUS" = $global:VRA_BG_STATUS__ALIVE})
 
 			$counters.inc('BGUpdated')
+
+			# Si le BG était en Ghost, 
+			if(!(isBGAlive -bg $bg))
+			{
+				# on compte juste la chose
+				$counters.inc('BGResurrected')
+			}
 		}
 
 	}
@@ -1345,6 +1362,8 @@ try
 	$counters.add('BGNotRenamed', '# Business Group not renamed')
 	$counters.add('BGResumeSkipped', '# Business Group skipped because of resume')
 	$counters.add('BGGhost',	'# Business Group set as "ghost"')
+	$counters.add('BGRenamed',	'# Business Group renamed')
+	$counters.add('BGResurrected', '# Business Group set alive again')
 	# Entitlements
 	$counters.add('EntCreated', '# Entitlements created')
 	$counters.add('EntUpdated', '# Entitlements updated')
@@ -1451,7 +1470,7 @@ try
 
 	# Calcul de la date dans le passé jusqu'à laquelle on peut prendre les groupes modifiés.
 	$aMomentInThePast = (Get-Date).AddDays(-$global:AD_GROUP_MODIFIED_LAST_X_DAYS)
-
+	
 	# Ajout de l'adresse par défaut à laquelle envoyer les mails. 
 	$capacityAlertMails = @($configGlobal.getConfigValue(@("mail", "capacityAlert")))
 


### PR DESCRIPTION
Le passage à la nouvelle structure organisationnelle de l'école implique plus de modifications que ce qui a été amené dans #194 . Les éléments manquants ont donc été ajoutés ici:
- Nouvelles "facultés" ajoutées à la liste de celles déjà ajoutées
- Nouveaux mapping d'unité pour avoir une unité de "gestion" avec un centre financier pour certaines unités de niveau 3.
- Ajout de 2 compteurs dans `sync-bg-from-ad.ps1`
- Augmentation de la profondeur de recherche dans LDAP pour les associations (`o=ehe,c=ch`). Avant, on arrivait à les récupérer en descendant de 2 niveaux et maintenant il faut 3 niveaux...
- Suite à un comportement bizarre dans la mise à jour de la "custom property" `ch.epfl.vra.bg.name` qui faisait que tous les BG n'étaient pas mis à jour, ajout d'un bout de code pour mettre d'office à jour si c'est incorrect. Ce bout de code pourra être enlevé par la suite.