### PR TITLE
Determine Applicative SVM to use

### DIFF
--- a/powershell/include/ArgsPrototypeChecker.inc.ps1
+++ b/powershell/include/ArgsPrototypeChecker.inc.ps1
@@ -310,7 +310,7 @@ class ArgsPrototypeChecker
                     # OU 
                     # Si la valeur de l'appel correspond à une autorisée
                     if( (($null -eq $allowedValue) -and ($callArg.Values[0] -ne "")) -or 
-                        ($callArg.Values[0].toLower() -eq $allowedValue))
+                        ($callArg.Values[0] -eq $allowedValue))
                     {
                         # On supprime les erreurs précédemment ajoutées s'il y en avait
                         $this.errors = @()

--- a/powershell/include/REST/RESTAPI.inc.ps1
+++ b/powershell/include/REST/RESTAPI.inc.ps1
@@ -71,7 +71,7 @@ class RESTAPI: APIUtils
 		$this.debugLog(("Invoke-RestMethod: $($method) $($uri) `nBody:`n{0}" -f (ConvertTo-Json -InputObject $body -Depth 20)))
 
 		# Si la requête est de la lecture
-		if($method.ToLower() -eq "get")
+		if($method -eq "get")
 		{
 			# Si on a l'info dans le cache, on la retourne
 			$cached = $this.getFromCache($uri)

--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -250,6 +250,42 @@ class NetAppAPI: RESTAPICurl
 
     <#
 		-------------------------------------------------------------------------------------
+        BUT : Calcule la moyenne des métriques passées et retourne le résultat
+        
+        IN  : $stats        -> Tableau avec les statistiques pour lesquelles calculer la moyenne
+        IN  : $metricList   -> Tableau avec les noms des métriques qu'il faut calculer
+        IN  : $metricType   -> Le type de métrique que l'on veut. Voir en haut du fichier.
+
+        RET : Tableau associatif avec en clef les noms des métriques désirées
+	#>
+    hidden [psobject] calcMetricsAverage([Array]$stats, [Array]$metricList, [NetAppMetricType]$metricType)
+    {
+        $result = @{}
+
+        # Addition des valeurs pour chaque compteur
+        $stats | ForEach-Object{
+            ForEach($metric in $metricList)
+            {
+                $result.$metric += $_.$metric.($metricType.toString())
+            }
+        }
+
+        # Si on a des résultats
+        if($stats.count -gt 0)
+        {
+            # Maintenant qu'on a additionné toutes les valeurs, on peut faire la moyenne
+            ForEach($metric in $metricList)
+            {
+                $result.$metric = $result.$metric / $stats.count
+            }
+        }
+        # Retour d'un tableau associatif avec les infos.
+        return $result
+    }
+
+
+    <#
+		-------------------------------------------------------------------------------------
         BUT : Attend qu'un job soit terminé
         
         IN  : $server       -> Le nom du serveur sur lequel tourne le job
@@ -413,6 +449,56 @@ class NetAppAPI: RESTAPICurl
     [string] getSVMClusterHost([PSObject]$svm)
     {
         return $this.getServerForObject([NetAppObjectType]::SVM, $svm.uuid)
+    }
+
+
+    <#
+		-------------------------------------------------------------------------------------
+        BUT : Retourne des informations sur les métriques d'une SVM
+        
+        IN  : $svm          -> Objet représentant la SVM
+        IN  : $protocol     -> Le nom du protocole pour lequel on veut les infos
+        IN  : $metricType   -> Le type de métrique que l'on veut. Voir en haut du fichier.
+
+        RET : Tableau associatif avec en clef les noms des métriques désirées (voir au début de
+                la fonction) et en valeur la moyenne sur la dernière semaine.
+
+        NOTE : L'appel à cette fonction ne retourne que les champs spécifiquement passés en paramètre.
+                Ce n'est donc pas comme si on pouvait juste "ajouter" des champs à ceux renvoyés par
+                défaut par l'appel retournant les détails d'une SVM.
+
+        https://nas-mcc-t.epfl.ch/docs/api/#/NAS/cifs_collection_performance_metrics_get
+
+	#>
+    [PSObject] getSVMMetrics([PSObject]$svm, [NetAppProtocol]$protocol, [NetAppMetricType]$metricType)
+    {
+        $protocolStr = $protocol.toString()
+        # On peut avoir "nfs3" et peut-être "nfs4" dans le futur donc on transforme pour avoir la bonne valeur pour l'URL après
+        if($protocolStr.StartsWith("nfs"))
+        {
+            $protocolStr = "nfs"
+        }
+        # Liste des métriques qu'on veut retourner 
+        $metricList = @(
+            "throughput",
+            "iops",
+            "latency"
+        )
+        $metricWithTypeList = @()
+        # Parcours des métriques 
+        $metricList | ForEach-Object { 
+            # Création du nom de la métrique, avec le type (total, read, ...)
+            $metricWithTypeList += ("{0}.{1}" -f $_, $metricType.toString()) 
+            # Ajout d'une donnée membre au résultat qui sera renvoyé
+            $result | Add-Member -NotePropertyName $_ -NotePropertyValue 0
+        }
+        $uri = "/api/protocols/{0}/services/{1}/metrics?fields={2}&interval=1w" -f $protocolStr, $svm.uuid, ($metricWithTypeList -join ",")
+        
+        $stats = $this.callAPI($uri, "GET", $null, "records", $true)
+        
+        # Calcul de la moyenne et retour
+        return $this.calcMetricsAverage($stats, $metricList, $metricType)
+
     }
 
     <#
@@ -656,6 +742,7 @@ class NetAppAPI: RESTAPICurl
         BUT : Retourne des informations sur les métriques d'un volume
         
         IN  : $vol   -> Objet représentant le volume
+        IN  : $metricType   -> Le type de métrique que l'on veut. Voir en haut du fichier.
 
         RET : Tableau associatif avec en clef les noms des métriques désirées (voir au début de
                 la fonction) et en valeur la moyenne sur la dernière semaine.
@@ -668,7 +755,6 @@ class NetAppAPI: RESTAPICurl
 	#>
     [PSObject] getVolumeMetrics([PSObject]$vol, [NetAppMetricType]$metricType)
     {
-        $result = @{}
 
         # Liste des métriques qu'on veut retourner 
         $metricList = @(
@@ -688,25 +774,8 @@ class NetAppAPI: RESTAPICurl
         
         $stats = $this.callAPI($uri, "GET", $null, "records", $true)
         
-        # Addition des valeurs pour chaque compteur
-        $stats | ForEach-Object{
-            ForEach($metric in $metricList)
-            {
-                $result.$metric += $_.$metric.($metricType.toString())
-            }
-        }
-
-        # Si on a des résultats
-        if($stats.count -gt 0)
-        {
-            # Maintenant qu'on a additionné toutes les valeurs, on peut faire la moyenne
-            ForEach($metric in $metricList)
-            {
-                $result.$metric = $result.$metric / $stats.count
-            }
-        }
-        # Retour d'un tableau associatif avec les infos.
-        return $result
+        # Calcul de la moyenne et retour
+        return $this.calcMetricsAverage($stats, $metricList, $metricType)
 
     }
 

--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -696,10 +696,14 @@ class NetAppAPI: RESTAPICurl
             }
         }
 
-        # Maintenant qu'on a additionné toutes les valeurs, on peut faire la moyenne
-        ForEach($metric in $metricList)
+        # Si on a des résultats
+        if($stats.count -gt 0)
         {
-            $result.$metric = $result.$metric / $stats.count
+            # Maintenant qu'on a additionné toutes les valeurs, on peut faire la moyenne
+            ForEach($metric in $metricList)
+            {
+                $result.$metric = $result.$metric / $stats.count
+            }
         }
         # Retour d'un tableau associatif avec les infos.
         return $result

--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -199,7 +199,7 @@ class NetAppAPI: RESTAPICurl
             else # Il y a plusieurs serveurs à interroger 
             {
                 # Si c'était une requête GET et qu'on a un nom pour la propriété où chercher le résultat
-                if(($method.ToLower() -eq "get"))
+                if(($method -eq "get"))
                 {
                     # Si la property existe
                     if(($getPropertyName -ne "") -and ([bool]($res.PSobject.Properties.name -eq $getPropertyName)))

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -254,7 +254,7 @@ class vRAAPI: RESTAPICurl
 			return $list| Where-Object { 
 				($_.extensionData.entries | Where-Object {
 					$null -ne ($_.key -eq $global:VRA_CUSTOM_PROP_EPFL_BG_ID) -and ( $null -ne ($_.value.values.entries | Where-Object { 
-						($null -ne $_.value.value) -and ($_.value.value -is [System.String]) -and ($_.value.value.toLower() -eq $customId.toLower()) } ) ) `
+						($null -ne $_.value.value) -and ($_.value.value -is [System.String]) -and ($_.value.value -eq $customId) } ) ) `
 														} `
 				)}
 		}

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -543,7 +543,6 @@ try
 
     }
 
-    
 
     # -------------------------------------------------------------------------
     # En fonction de l'action demandée
@@ -561,7 +560,7 @@ try
             switch($volType)
             {
                 # ---- Volume Applicatif
-                ([XaaSNASVolType]::app).ToString()
+                app
                 {
                     $nameGeneratorNAS.setApplicativeDetails($bgId, $volName)
 
@@ -584,7 +583,7 @@ try
                 }
 
                 # ---- Volume Collaboratif
-                ([XaaSNASVolType]::col).ToString()
+                col
                 {
                     # Check des valeurs passées pour les snapshots
                     if( (($snapPercent -eq 0) -and ($snapPolicy -ne "")) -or ( ($snapPercent -ne 0) -and ($snapPolicy -eq "") ))
@@ -629,14 +628,14 @@ try
             }
 
             # En fonction du type d'accès qui a été demandé
-            switch($access.toLower())
+            switch($access)
             {
-                ([NetAppProtocol]::cifs).ToString()
+                cifs
                 {
                     $securityStyle = "ntfs"
                 }
 
-                ([NetAppProtocol]::nfs3).ToString()
+                nfs3
                 {
                     $securityStyle = "unix"
                 }
@@ -673,7 +672,7 @@ try
             switch($access)
             {
                 # ------------ CIFS
-                ([NetAppProtocol]::cifs).ToString()
+                cifs
                 {
                     $logHistory.addLine( ("Adding CIFS share '{0}' to point on '{1}'..." -f $volName, $mountPoint))
                     $netapp.addCIFSShare($volName, $svmObj, $mountPoint)
@@ -685,7 +684,7 @@ try
                     switch($volType)
                     {
                         # ---- Volume Applicatif
-                        ([XaaSNASVolType]::app).ToString()
+                        app
                         {
                             # Ajout de l'export policy
                             $exportPol, $null = addNFSExportPolicy -nameGeneratorNAS $nameGeneratorNAS -netapp $netapp -volumeName $volName -svmObj $svmObj `
@@ -693,7 +692,7 @@ try
                         }
 
                         # ---- Volume Collaboratif
-                        ([XaaSNASVolType]::col).ToString()
+                        coll
                         {
                             $logHistory.addLine(("Checking if Export Policy '{0}' exists on SVM '{1}'..." -f $global:EXPORT_POLICY_DENY_NFS_ON_CIFS, $svmObj.name))
                             $exportPol = $netapp.getExportPolicyByName($svmObj, $global:EXPORT_POLICY_DENY_NFS_ON_CIFS)
@@ -760,7 +759,7 @@ try
 
 
                 # ------------ NFS
-                ([NetAppProtocol]::nfs3).ToString()
+                nfs3
                 {
                     # Ajout de l'export policy
                     $exportPol, $result = addNFSExportPolicy -nameGeneratorNAS $nameGeneratorNAS -netapp $netapp -volumeName $volName -svmObj $svmObj `

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -774,7 +774,7 @@ try
             # 3. Politique de snapshot
 
             # Si volume collaboratif ET qu'il faut avoir les snapshots
-            if(( $volType -eq ([XaaSNASVolType]::col).ToString()) -and $snapPolicy -ne "")
+            if(( $volType -eq [XaaSNASVolType]::col) -and $snapPolicy -ne "")
             {
                 $snapPolicyObj = $netapp.getSnapshotPolicyByName($snapPolicy)
                 if($null -eq $snapPolicyObj)


### PR DESCRIPTION
Changement de la manière de faire pour déterminer sur quelle SVM Applicative on allait mettre un nouveau volume demandé.
Jusqu'à présent, on prenait la SVM qui avait le plus de place sur l'aggregat en-dessous mais étant donné qu'on a la configuration suivante, ça ne joue pas.

```
SVM-NFS-1    >   Aggregat A
SVM-NFS-2    >   Aggregat B
SVM-CIFS-1   >   Aggregat B
SVM-CIFS-2   >   Aggregat B
```
Du coup, ce qu'on fait, c'est qu'on se base plus sur les IOPS qui sont faites sur chacune des SVM qui sert le protocole demandé pour le nouveau volume et on ajouter celui-ci sur la SVM qui est le moins chargée.

- Changement de la manière dont les `switch/case` sont codés, simplifications pour les comparaisons
- Suppression de l'utilisation de `.toLower()` pour la comparaison `-eq` car elle est par défaut "case insensitive"