### PR TITLE
Handle bg duplicate names

### DIFF
--- a/powershell/resources/mail-templates/bg-rename-duplicate.html
+++ b/powershell/resources/mail-templates/bg-rename-duplicate.html
@@ -1,0 +1,14 @@
+Les renommage de BG suivants n'ont pas pu être effectués car il existait déjà un BG avec le nouveau nom.<br>
+Il se peut qu'un changement au niveau des sources de données fasse que le BG avec le nom "cible" soit en fait un BG qui est passé en "ghost" car devant être supprimé. Et donc, vu qu'il garde
+son nom "normal" pendant qu'il est en mode "ghost", il n'est pas possible de renommer l'autre BG pour qu'il prenne son nouveau nom.<br>
+Pour la résolution, il faut faire les étapes suivantes:
+<ol>
+    <li>Se connecter à vRA pour vérifier que le BG qui porte le nouveau nom soit effectivement passé en "ghost"</li>
+    <li>Si le BG est effectivement passé en "ghost", utiliser le script <i>clean-ghost-bg.ps1</i> en lui passant en paramètre le nom du BG à supprimer (voir le USAGE du script pour les paramètres)</li>
+</ol>
+
+Liste des renommages concernés:
+<br>
+<ul>
+    <li>{{bgRenameList}}</li>
+</ul>

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -359,6 +359,8 @@ function createOrUpdateBG
 	else
 	{
 
+		$logHistory.addLineAndDisplay(("-> BG '{0}' already exists" -f $bg.Name))
+		
 		$counters.inc('BGExisting')
 		# ==========================================================================================
 


### PR DESCRIPTION
PR en attente pour le moment car finalement, ce qui a entrainé sa création c'était juste probablement une mauvaise manipulation au niveau des unités dans LDAP. Donc il n'est potentiellement pas pertinent de complexifier le code pour gérer un cas de figure qui ne pourrait finalement pas se reproduire.
Bref, à voir avec le temps. Mais s'il faut finaliser cette PR, il faut encore:

- [x] Faire en sorte qu'il y ait une unité A qui disparaisse et une unité B qui doive être renommée en unité A (faire le nécessaire dans les groupes AD pour simuler ceci)
- [x] Tester le code qui notifie du problème par mail
- [x] Modifier le script `clean-ghost-bg.ps1` pour lui ajouter la possibilité de prendre en paramètre `-bgName <bgName>` afin de ne pouvoir clean qu'un seul BG
- [x] Valider la chose et mettre en production