### PR TITLE
Add vsissp admins to groups groups

### DIFF
--- a/powershell/include/EPFLLDAP.inc.ps1
+++ b/powershell/include/EPFLLDAP.inc.ps1
@@ -262,7 +262,9 @@ class EPFLLDAP
 	<#
 	-------------------------------------------------------------------------------------
 		BUT : Retourne les informations d'une unité
+
 		IN  : $unitUniqueIdentifier	-> Identifiant unique de l'unité (numérique)
+
 		RET : Objet avec les informations suivantes
 				- description
 				- uniqueidentifier
@@ -297,4 +299,44 @@ class EPFLLDAP
 		return $null
 
 	}
+
+
+	<#
+	-------------------------------------------------------------------------------------
+		BUT : Retourne les informations d'un groupe
+
+		IN  : $groupName	-> Nom du groupe
+
+		RET : Objet avec les informations suivantes
+				- description
+				- uniqueidentifier
+				- memberuid
+				- displayname
+				- member
+				- cn
+				- memberuniqueid
+				- adspath
+				- objectclass
+				- gidnumber
+	#>
+	[PSObject] getGroupInfos([string]$groupName)
+	{
+
+		# Parcours des informations que l'on a
+		ForEach($ldapInfos in $this.LDAPconfig.facultyUnits.locations)
+		{
+
+			# Recherche des groupes de manière récursive
+			$group = $this.LDAPSearch($this.LDAPconfig.facultyUnits.server, $ldapInfos.rootDN, "subtree", `
+									("(&(objectClass=EPFLGroupOfPersons)(cn={0}))" -f $groupName), @("*"))
+
+			if($group.count -eq 1)
+			{
+				return $group[0].Properties
+			}
+		}
+
+		return $null
+	}
+
 }

--- a/powershell/include/define.inc.ps1
+++ b/powershell/include/define.inc.ps1
@@ -43,6 +43,9 @@ $global:VRA_TENANT__EPFL         = "EPFL"
 $global:VRA_TENANT__ITSERVICES   = "ITServices"
 $global:VRA_TENANT__RESEARCH     = "Research"
 
+# Nom du groupe "groups" utilisé par les admins vRA. Sera utilisé principalement pour gérer les groupes dans "groups"
+$global:VRA_GROUPS_ADMIN_GROUP = "vsissp-prod-admins"
+
 # Nom des tenants que l'on devra traiter
 $global:TARGET_TENANT_LIST = @($global:VRA_TENANT__EPFL, $global:VRA_TENANT__ITSERVICES, $global:VRA_TENANT__RESEARCH<#, $global:VRA_TENANT__DEFAULT #>)
 

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -679,6 +679,9 @@ try
 							$configVra.getConfigValue(@($targetEnv, "db", "password")),
 							$configVra.getConfigValue(@($targetEnv, "db", "port")))
 
+	# Pour faire les recherches dans LDAP
+	$ldap = [EPFLLDAP]::new()
+								
 	Import-Module ActiveDirectory
 
 	if($SIMULATION_MODE)
@@ -749,9 +752,6 @@ try
 
 			# Ajout du nécessaire pour gérer les notifications pour ce Tenant
 			$notifications.missingEPFLADGroups = @()
-
-			# Pour faire les recherches dans LDAP
-			$ldap = [EPFLLDAP]::new()
 
 			# Recherche de toutes les facultés
 			$facultyList = $ldap.getLDAPFacultyList() #  | Where-Object { $_['name'] -eq "ASSOCIATIONS" } # Décommenter et modifier pour limiter à une faculté donnée


### PR DESCRIPTION
Ajout du groupe "vsissp-prod-admins" aux groupes qui sont créés dans "groups.epfl.ch" pour continuer à permettre aux admins IaaS d'avoir les droits sur le groupe.

