### PR TITLE
Release 29 (CHG0040079)

### DIFF
--- a/powershell/clean-ghost-bg.ps1
+++ b/powershell/clean-ghost-bg.ps1
@@ -354,7 +354,7 @@ function handleNotifications
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logPath = @('vra', 'clean-ghost-bg-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logPath = @('vra', ('clean-ghost-bg-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()))
 	$logHistory =[LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script

--- a/powershell/clean-ghost-bg.ps1
+++ b/powershell/clean-ghost-bg.ps1
@@ -354,8 +354,8 @@ function handleNotifications
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logName = 'vra-clean-ghost-bg-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory =[LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+	$logPath = @('vra', 'clean-ghost-bg-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logHistory =[LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/clean-iso-folders.ps1
+++ b/powershell/clean-iso-folders.ps1
@@ -104,7 +104,7 @@ function Set-CDDriveAndAnswer
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logPath = @('vra', 'clean-iso-folders-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logPath = @('vra', ('clean-iso-folders-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()))
 	$logHistory =[LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script

--- a/powershell/clean-iso-folders.ps1
+++ b/powershell/clean-iso-folders.ps1
@@ -104,8 +104,8 @@ function Set-CDDriveAndAnswer
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logName = 'vra-Clean-ISO-Folders-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory =[LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+	$logPath = @('vra', 'clean-iso-folders-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logHistory =[LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/include/ArgsPrototypeChecker.inc.ps1
+++ b/powershell/include/ArgsPrototypeChecker.inc.ps1
@@ -310,7 +310,7 @@ class ArgsPrototypeChecker
                     # OU 
                     # Si la valeur de l'appel correspond à une autorisée
                     if( (($null -eq $allowedValue) -and ($callArg.Values[0] -ne "")) -or 
-                        ($callArg.Values[0].toLower() -eq $allowedValue))
+                        ($callArg.Values[0] -eq $allowedValue))
                     {
                         # On supprime les erreurs précédemment ajoutées s'il y en avait
                         $this.errors = @()

--- a/powershell/include/LogHistory.inc.ps1
+++ b/powershell/include/LogHistory.inc.ps1
@@ -22,14 +22,15 @@ class LogHistory
               Le dossier créé portera le nom $logName et c'est dans celui-ci qu'on créera les fichiers logs,
               un par jour.
 
-        IN  : $logName          -> Nom du log
+        IN  : $logPath          -> Tableau avec le "chemin" jusqu'au log
         IN  : $rootFolderPath   -> Chemin jusqu'au dossier racine où mettre les logs.
         IN  : $nbDaysToKeep     -> Le nombre jours de profondeur que l'on veut garder
 	#>
-	LogHistory([string]$logName, [string]$rootFolderPath, [int]$nbDaysToKeep)
+	LogHistory([Array]$logPath, [string]$rootFolderPath, [int]$nbDaysToKeep)
 	{
         # On créé un dossier avec la date du jour pour le log
-        $this.logFolderPath = [IO.Path]::Combine($rootFolderPath, $logName, (Get-Date -format "yyyy-MM-dd"))
+        $cmd = '$this.logFolderPath = [IO.Path]::Combine($rootFolderPath, "{0}", (Get-Date -format "yyyy-MM-dd"))' -f ($logPath -join '","')
+        Invoke-Expression $cmd
         $this.logFilename = ("{0}.log" -f (Get-Date -Format "HH-mm-ss.fff"))
 
         # Si le dossier pour les logs n'existe pas encore,

--- a/powershell/include/LogHistory.inc.ps1
+++ b/powershell/include/LogHistory.inc.ps1
@@ -28,9 +28,14 @@ class LogHistory
 	#>
 	LogHistory([Array]$logPath, [string]$rootFolderPath, [int]$nbDaysToKeep)
 	{
-        # On créé un dossier avec la date du jour pour le log
-        $cmd = '$this.logFolderPath = [IO.Path]::Combine($rootFolderPath, "{0}", (Get-Date -format "yyyy-MM-dd"))' -f ($logPath -join '","')
+        # Dossier pour tous les fichiers du log
+        $allLogFolder = ""
+        $cmd = '$allLogFolder = [IO.Path]::Combine($rootFolderPath, "{0}")' -f ($logPath -join '","')
         Invoke-Expression $cmd
+
+        # On créé un dossier avec la date du jour pour le log
+        $this.logFolderPath = [IO.Path]::Combine($allLogFolder, (Get-Date -format "yyyy-MM-dd"))
+        
         $this.logFilename = ("{0}.log" -f (Get-Date -Format "HH-mm-ss.fff"))
 
         # Si le dossier pour les logs n'existe pas encore,
@@ -38,12 +43,11 @@ class LogHistory
         {
             New-Item -ItemType Directory -Force -Path $this.logFolderPath | Out-null
         }
-        else # Le dossier pour les logs existe déjà
-        {
-            # Suppression des "vieux logs"
-            Get-ChildItem $this.logFolderPath | `
-                Where-Object {$_.CreationTime -le (Get-Date).AddDays(-$nbDaysToKeep) } | Remove-Item -Force
-        }
+        
+        # Suppression des "vieux logs"
+        Get-ChildItem $allLogFolder -Directory | `
+            Where-Object {$_.CreationTime -le (Get-Date).AddDays(-$nbDaysToKeep) } | Remove-Item -Force -Recurse
+        
 
     }
 

--- a/powershell/include/REST/RESTAPI.inc.ps1
+++ b/powershell/include/REST/RESTAPI.inc.ps1
@@ -71,7 +71,7 @@ class RESTAPI: APIUtils
 		$this.debugLog(("Invoke-RestMethod: $($method) $($uri) `nBody:`n{0}" -f (ConvertTo-Json -InputObject $body -Depth 20)))
 
 		# Si la requête est de la lecture
-		if($method.ToLower() -eq "get")
+		if($method -eq "get")
 		{
 			# Si on a l'info dans le cache, on la retourne
 			$cached = $this.getFromCache($uri)

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -254,7 +254,7 @@ class vRAAPI: RESTAPICurl
 			return $list| Where-Object { 
 				($_.extensionData.entries | Where-Object {
 					$null -ne ($_.key -eq $global:VRA_CUSTOM_PROP_EPFL_BG_ID) -and ( $null -ne ($_.value.values.entries | Where-Object { 
-						($null -ne $_.value.value) -and ($_.value.value -is [System.String]) -and ($_.value.value.toLower() -eq $customId.toLower()) } ) ) `
+						($null -ne $_.value.value) -and ($_.value.value -is [System.String]) -and ($_.value.value -eq $customId) } ) ) `
 														} `
 				)}
 		}

--- a/powershell/mynas-process-hd-actions-requests.ps1
+++ b/powershell/mynas-process-hd-actions-requests.ps1
@@ -99,7 +99,7 @@ function setActionStatus
 try
 {
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-hd-actions', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'process-hd-actions'), $global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-infos-from-cadi.ps1
+++ b/powershell/mynas-process-infos-from-cadi.ps1
@@ -83,7 +83,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-info-from-cadi', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'process-info-from-cadi'), $global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-user-delete-requests.ps1
+++ b/powershell/mynas-process-user-delete-requests.ps1
@@ -88,7 +88,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-user-delete', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'process-user-delete'), $global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-user-rename-requests.ps1
+++ b/powershell/mynas-process-user-rename-requests.ps1
@@ -181,7 +181,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-username-rename', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'process-username-rename'), $global:LOGS_FOLDER, 30)
     
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-waiting-quota-update-requests.ps1
+++ b/powershell/mynas-process-waiting-quota-update-requests.ps1
@@ -141,7 +141,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-quota-update', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'process-quota-update'), $global:LOGS_FOLDER, 30)
     
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-www-push-user-quota-usage.ps1
+++ b/powershell/mynas-www-push-user-quota-usage.ps1
@@ -157,7 +157,7 @@ function getFSNoFromUID
 try
 {
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-push-user-quota-usage', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'push-user-quota-usage'), $global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/resources/mail-templates/bg-rename-duplicate.html
+++ b/powershell/resources/mail-templates/bg-rename-duplicate.html
@@ -1,0 +1,14 @@
+Les renommage de BG suivants n'ont pas pu être effectués car il existait déjà un BG avec le nouveau nom.<br>
+Il se peut qu'un changement au niveau des sources de données fasse que le BG avec le nom "cible" soit en fait un BG qui est passé en "ghost" car devant être supprimé. Et donc, vu qu'il garde
+son nom "normal" pendant qu'il est en mode "ghost", il n'est pas possible de renommer l'autre BG pour qu'il prenne son nouveau nom.<br>
+Pour la résolution, il faut faire les étapes suivantes:
+<ol>
+    <li>Se connecter à vRA pour vérifier que le BG qui porte le nouveau nom soit effectivement passé en "ghost"</li>
+    <li>Si le BG est effectivement passé en "ghost", utiliser le script <i>clean-ghost-bg.ps1</i> en lui passant en paramètre le nom du BG à supprimer (voir le USAGE du script pour les paramètres)</li>
+</ol>
+
+Liste des renommages concernés:
+<br>
+<ul>
+    <li>{{bgRenameList}}</li>
+</ul>

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -646,8 +646,8 @@ $RESEARCH_TEST_NB_PROJECTS_MAX = 5
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logName = 'vra-sync-AD-from-LDAP-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory = [LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+	$logPath = @('vra', 'sync-AD-from-LDAP-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -646,7 +646,7 @@ $RESEARCH_TEST_NB_PROJECTS_MAX = 5
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logPath = @('vra', 'sync-AD-from-LDAP-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logPath = @('vra', ('sync-AD-from-LDAP-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()))
 	$logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1343,8 +1343,8 @@ $global:existingADGroups = @()
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logName = 'vra-sync-BG-from-AD-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory =[LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+	$logPath = @('vra', 'sync-BG-from-AD-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logHistory =[LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1343,7 +1343,7 @@ $global:existingADGroups = @()
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logPath = @('vra', 'sync-BG-from-AD-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logPath = @('vra', ('sync-BG-from-AD-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()))
 	$logHistory =[LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -359,6 +359,8 @@ function createOrUpdateBG
 	else
 	{
 
+		$logHistory.addLineAndDisplay(("-> BG '{0}' already exists" -f $bg.Name))
+
 		$counters.inc('BGExisting')
 		# ==========================================================================================
 
@@ -400,6 +402,23 @@ function createOrUpdateBG
 			if($bg.name -ne $bgName)
 			{
 				$logHistory.addLineAndDisplay(("-> Renaming BG '{0}' to '{1}'" -f $bg.name, $bgName))
+
+				<# On commence par regarder s'il n'y aurait pas par hasard déjà un BG avec le nouveau nom.
+				 Ceci peut arriver si on supprime une unité/service IT et qu'on change le nom d'un autre en
+				 même temps pour reprendre le nom de ce qui a été supprimé. Etant donné que les BG passent
+				 en "ghost" sans être renommé dans le cas où ils doivent être supprimés, il y a toujours 
+				 conflit de noms
+				#>
+				if($null -ne $vra.getBG($bgName)) 
+				{
+					$logHistory.addWarningAndDisplay(("-> Impossible to rename BG '{0}' to '{1}'. A BG with the new name already exists" -f $bg.name, $bgName))
+					$notifications.bgNameDuplicate += ("{0} &gt;&gt; {1}" -f $bg.name, $bgName)
+					$counters.inc('BGNotRenamed')
+
+					# On sort et on renvoie $null pour qu'on n'aille pas plus loin dans le traitement de ce BG pour le moment.
+					return $null
+				}
+				
 				# Recherche du nom actuel du dossier où se trouvent les ISO du BG
 				$bgISOFolderCurrent = $nameGenerator.getNASPrivateISOPath($bg.name)
 				# Recherche du nouveau nom du dossier où devront se trouver les ISO
@@ -434,7 +453,7 @@ function createOrUpdateBG
 				$bg = $vra.updateBG($bg, $bgName, $bgDesc, $machinePrefixId, @{"$global:VRA_CUSTOM_PROP_VRA_BG_NAME" = $bgName})
 
 				$counters.inc('BGRenamed')
-				
+
 			}# Fin s'il y a eu changement de nom 
 
 			$logHistory.addLineAndDisplay(("-> Updating and/or Reactivating BG '{0}' to '{1}'" -f $bg.name, $bgName))
@@ -1086,6 +1105,15 @@ function handleNotifications
 					$templateName = "day2-actions-not-found"
 				}
 
+				# ---------------------------------------
+				# Pas possible de renommer un BG car le nouveau nom existe déjà
+				'bgNameDuplicate'
+				{
+					$valToReplace.bgRenameList = ($uniqueNotifications -join "</li>`n<li>")
+					$mailSubject = "Error - BG cannot be renamed because of duplicate"
+					$templateName = "bg-rename-duplicate"
+				}
+
 				default
 				{
 					# Passage à l'itération suivante de la boucle
@@ -1397,6 +1425,7 @@ try
 	$notifications=@{bgWithoutCustomPropStatus = @()
 					bgWithoutCustomPropType = @()
 					bgSetAsGhost = @()
+					bgNameDuplicate = @()
 					emptyADGroups = @()
 					adGroupsNotFound = @()
 					ISOFolderNotRenamed = @()
@@ -1421,7 +1450,7 @@ try
 						 $configNSX.getConfigValue(@($targetEnv, "user")), 
 						 $configNSX.getConfigValue(@($targetEnv, "password")))
 
-	$doneBGList = @()
+	$doneElementList = @()
 
 	# Si on doit tenter de reprendre une exécution foirée ET qu'un fichier de progression existait, on charge son contenu
 	if($resume)
@@ -1430,8 +1459,8 @@ try
 		$progress = $resumeOnFail.load()
 		if($null -ne $progress)
 		{
-			$doneBGList = $progress
-			$logHistory.addLineAndDisplay(("Progress file found, using it! {0} BG already processed. Skipping to unprocessed (could take some time)..." -f $doneBGList.Count))
+			$doneElementList = $progress
+			$logHistory.addLineAndDisplay(("Progress file found, using it! {0} BG already processed. Skipping to unprocessed (could take some time)..." -f $doneElementList.Count))
 		}
 		else
 		{
@@ -1565,8 +1594,8 @@ try
 		# Nom du préfix de machine
 		$machinePrefixName = $nameGenerator.getVMMachinePrefix()
 
-		# Si on a déjà traité le BG
-		if($doneBGList -contains $bgName)
+		# Si on a déjà traité le groupe AD
+		if( ($doneElementList | Foreach-Object { $_.adGroup } ) -contains $_.name)
 		{
 			$counters.inc('BGResumeSkipped')
 			# passage au BG suivant
@@ -1645,7 +1674,10 @@ try
 			if(($null -ne $_.whenChanged) -and ([DateTime]::Parse($_.whenChanged.toString()) -lt $aMomentInThePast))
 			{
 				$logHistory.addLineAndDisplay(("--> Skipping group, modification date older than {0} day(s) ago ({1})" -f $global:AD_GROUP_MODIFIED_LAST_X_DAYS, $_.whenChanged))
-				$doneBGList += $bgName
+				$doneElementList += @{
+					adGroup = $_.name
+					bgName = $bgName
+				}
 				$counters.inc('BGExisting')
 				return
 			}
@@ -1662,7 +1694,10 @@ try
 
 			# On enregistre quand même le nom du Business Group, même si on n'a pas pu continuer son traitement. Si on ne fait pas ça et qu'il existe déjà,
 			# il sera supprimé à la fin du script, chose qu'on ne désire pas.
-			$doneBGList += $bgName
+			$doneElementList += @{
+				adGroup = $_.name
+				bgName = $bgName
+			}
 
 			# Note: Pour passer à l'élément suivant dans un ForEach-Object, il faut faire "return" et non pas "continue" comme dans une boucle standard
 			return
@@ -1685,11 +1720,14 @@ try
 		$bg = createOrUpdateBG -vra $vra -bgEPFLID $bgEPFLID -tenantName $targetTenant -bgName $bgName -bgDesc $bgDesc `
 									-machinePrefixName $machinePrefixName -financeCenter $financeCenter -capacityAlertsEmail ($capacityAlertMails -join ",") 
 
-		# Si BG pas créé, on passe au suivant (la fonction de création a déjà enregistré les infos sur ce qui ne s'est pas bien passé)
+		# Si BG pas créé, on passe au s	uivant (la fonction de création a déjà enregistré les infos sur ce qui ne s'est pas bien passé)
 		if($null -eq $bg)
 		{
 			# On note quand même le BG comme pas traité
-			$doneBGList += $bgName
+			$doneElementList += @{
+				adGroup = $_.name
+				bgName = $bgName
+			}
 			# Note: Pour passer à l'élément suivant dans un ForEach-Object, il faut faire "return" et non pas "continue" comme dans une boucle standard
 			return
 		}
@@ -1814,9 +1852,12 @@ try
 		# Verrouillage de la section de firewall (si elle ne l'est pas encore)
 		$nsxFWSection = $nsx.lockFirewallSection($nsxFWSection.id)
 
-		$doneBGList += $bg.name
+		$doneElementList += @{
+			adGroup = $_.name
+			bgName = $bgName
+		}
 		# On sauvegarde l'avancement dans le cas où on arrêterait le script au milieu manuellement
-		$resumeOnFail.save($doneBGList)	
+		$resumeOnFail.save($doneElementList)	
 
 	}# Fin boucle de parcours des groupes AD pour l'environnement/tenant donnés
 
@@ -1839,7 +1880,7 @@ try
 			$notifications.bgWithoutCustomPropType += $_.name
 			$logHistory.addLineAndDisplay(("-> Custom Property '{0}' not found in Business Group '{1}'..." -f $global:VRA_CUSTOM_PROP_VRA_BG_TYPE, $_.name))
 		}
-		elseif($isBGOfType -and ($doneBGList -notcontains $_.name))
+		elseif($isBGOfType -and ( ($doneElementList | ForEach-Object {$_.bgName} ) -notcontains $_.name))
 		{
 			$logHistory.addLineAndDisplay(("-> Setting Business Group '{0}' as Ghost..." -f $_.name))
 			setBGAsGhostIfNot -vra $vra -bg $_ | Out-Null
@@ -1897,8 +1938,8 @@ try
 catch # Dans le cas d'une erreur dans le script
 {
 	# Sauvegarde de la progression en cas d'erreur
-	$logHistory.addLineAndDisplay(("Saving progress for future resume ({0} BG processed)" -f $doneBGList.Count))
-	$resumeOnFail.save($doneBGList)	
+	$logHistory.addLineAndDisplay(("Saving progress for future resume ({0} BG processed)" -f $doneElementList.Count))
+	$resumeOnFail.save($doneElementList)	
 
 	# Récupération des infos
 	$errorMessage = $_.Exception.Message

--- a/powershell/vsphere-update-vm-notes.ps1
+++ b/powershell/vsphere-update-vm-notes.ps1
@@ -107,8 +107,8 @@ try
 {
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logName = 'vsphere-update-VM-notes-{0}' -f $targetEnv.ToLower()
-    $logHistory = [LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+    $logPath = @('vsphere', 'update-VM-notes-{0}' -f $targetEnv.ToLower())
+    $logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/vsphere-update-vm-notes.ps1
+++ b/powershell/vsphere-update-vm-notes.ps1
@@ -107,7 +107,7 @@ try
 {
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logPath = @('vsphere', 'update-VM-notes-{0}' -f $targetEnv.ToLower())
+    $logPath = @('vsphere', ('update-VM-notes-{0}' -f $targetEnv.ToLower()))
     $logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script

--- a/powershell/xaas-backup-endpoint.ps1
+++ b/powershell/xaas-backup-endpoint.ps1
@@ -94,6 +94,7 @@ $ACTION_GET_RESTORE_STATUS = "getRestoreStatus"
 $ACTION_VM_HAS_RUNNING_SNAPSHOT = "VMHasSnap"
 
 $NBU_CATEGORY = "NBU"
+$BACKUP_POLICY_TYPE_FILTER = "VMware"
 
 # -------------------------------------------- FONCTIONS ---------------------------------------------------
 
@@ -244,6 +245,8 @@ try
                 - Ceux qui ne sont pas encore expirés  #>
             $nbu.getVMBackupList($vmName) | Where-Object {
                 $_.attributes.backupStatus -eq 0 `
+                -and `
+                $_.attributes.policyType -eq $BACKUP_POLICY_TYPE_FILTER `
                 -and `
                 (Get-Date) -lt [DateTime]($_.attributes.expiration -replace "Z", "")} | ForEach-Object {
 

--- a/powershell/xaas-backup-endpoint.ps1
+++ b/powershell/xaas-backup-endpoint.ps1
@@ -111,7 +111,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-backup', (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new(@('xaas','backup', 'endpoint'), $global:LOGS_FOLDER, 30)
 
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-backup-sync-vm-tags.ps1
+++ b/powershell/xaas-backup-sync-vm-tags.ps1
@@ -87,9 +87,9 @@ function backupTagRepresentation([string]$backupTag)
 
 try
 {
-    $logName = 'xaas-backup-sync-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
+    $logPath = @('xaas', 'backup', 'sync-vm-tags-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-backup-sync-vm-tags.ps1
+++ b/powershell/xaas-backup-sync-vm-tags.ps1
@@ -87,7 +87,7 @@ function backupTagRepresentation([string]$backupTag)
 
 try
 {
-    $logPath = @('xaas', 'backup', 'sync-vm-tags-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+    $logPath = @('xaas', 'backup', ('sync-vm-tags-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()))
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
     $logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 

--- a/powershell/xaas-billing.ps1
+++ b/powershell/xaas-billing.ps1
@@ -215,7 +215,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-billing', (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new(@('xaas', 'billing'), $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -485,7 +485,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-nas', (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new(@('xaas','nas', 'endpoint'), $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -161,12 +161,13 @@ function getNextColVolName([NetAppAPI]$netapp, [NameGeneratorNAS]$nameGeneratorN
 
     IN  : $netapp           -> Objet de la classe NetAppAPI pour se connecter au NetApp
     IN  : $svmList          -> Liste des SVM parmi lesquelles choisir
+    IN  : $protocol         -> Nom du protocol qui a été demandé pour le volume
 
     RET : Objet représentant la SVM
 #>
-function chooseAppSVM([NetAppAPI]$netapp, [Array]$svmList)
+function chooseAppSVM([NetAppAPI]$netapp, [Array]$svmList, [NetAppProtocol]$protocol)
 {
-    $lessCharged = $null
+    $iops = $null
     $targetSVM = $null
     # Parcours des SVM
     ForEach($svmName in $svmList)
@@ -180,12 +181,13 @@ function chooseAppSVM([NetAppAPI]$netapp, [Array]$svmList)
             Throw ("Defined applicative SVM ({0}) not found. Please check 'data/xaas/nas/applicatives-svm.json' content")
         }
 
-        $aggr = $netapp.getAggregateById($svm.aggregates[0].uuid)
+        # Recherche des IOPS de la SVM
+        $svmIOPS = $netapp.getSVMMetrics($svm, $protocol, [NetAppMetricType]::total).iops
 
         # Si l'aggregat courant est moins utilisé
-        if( ($null -eq $lessCharged) -or ($aggr.space.block_storage.used -lt $lessCharged.space.block_storage.used))
+        if( ($null -eq $iops) -or ($svmIOPS -lt $iops))
         {
-            $lessCharged = $aggr
+            $iops = $svmIOPS
             $targetSVM = $svm
         }
     }
@@ -541,7 +543,6 @@ try
 
     }
 
-    
 
     # -------------------------------------------------------------------------
     # En fonction de l'action demandée
@@ -559,7 +560,7 @@ try
             switch($volType)
             {
                 # ---- Volume Applicatif
-                ([XaaSNASVolType]::app).ToString()
+                app
                 {
                     $nameGeneratorNAS.setApplicativeDetails($bgId, $volName)
 
@@ -569,7 +570,7 @@ try
 
                     # Choix de la SVM
                     $logHistory.addLine("Choosing SVM for volume...")
-                    $svmObj = chooseAppSVM -netapp $netapp -svmList $appSVMList.($targetEnv.ToLower()).($access.ToLower())
+                    $svmObj = chooseAppSVM -netapp $netapp -svmList $appSVMList.($targetEnv.ToLower()).($access.ToLower()) -protocol ([NetAppProtocol]$access)
                     $logHistory.addLine( ("SVM will be '{0}'" -f $svmObj.name) )
 
                     # Pas d'espace réservé pour les snapshots
@@ -582,7 +583,7 @@ try
                 }
 
                 # ---- Volume Collaboratif
-                ([XaaSNASVolType]::col).ToString()
+                col
                 {
                     # Check des valeurs passées pour les snapshots
                     if( (($snapPercent -eq 0) -and ($snapPolicy -ne "")) -or ( ($snapPercent -ne 0) -and ($snapPolicy -eq "") ))
@@ -627,14 +628,14 @@ try
             }
 
             # En fonction du type d'accès qui a été demandé
-            switch($access.toLower())
+            switch($access)
             {
-                ([NetAppProtocol]::cifs).ToString()
+                cifs
                 {
                     $securityStyle = "ntfs"
                 }
 
-                ([NetAppProtocol]::nfs3).ToString()
+                nfs3
                 {
                     $securityStyle = "unix"
                 }
@@ -671,7 +672,7 @@ try
             switch($access)
             {
                 # ------------ CIFS
-                ([NetAppProtocol]::cifs).ToString()
+                cifs
                 {
                     $logHistory.addLine( ("Adding CIFS share '{0}' to point on '{1}'..." -f $volName, $mountPoint))
                     $netapp.addCIFSShare($volName, $svmObj, $mountPoint)
@@ -683,7 +684,7 @@ try
                     switch($volType)
                     {
                         # ---- Volume Applicatif
-                        ([XaaSNASVolType]::app).ToString()
+                        app
                         {
                             # Ajout de l'export policy
                             $exportPol, $null = addNFSExportPolicy -nameGeneratorNAS $nameGeneratorNAS -netapp $netapp -volumeName $volName -svmObj $svmObj `
@@ -691,7 +692,7 @@ try
                         }
 
                         # ---- Volume Collaboratif
-                        ([XaaSNASVolType]::col).ToString()
+                        coll
                         {
                             $logHistory.addLine(("Checking if Export Policy '{0}' exists on SVM '{1}'..." -f $global:EXPORT_POLICY_DENY_NFS_ON_CIFS, $svmObj.name))
                             $exportPol = $netapp.getExportPolicyByName($svmObj, $global:EXPORT_POLICY_DENY_NFS_ON_CIFS)
@@ -758,7 +759,7 @@ try
 
 
                 # ------------ NFS
-                ([NetAppProtocol]::nfs3).ToString()
+                nfs3
                 {
                     # Ajout de l'export policy
                     $exportPol, $result = addNFSExportPolicy -nameGeneratorNAS $nameGeneratorNAS -netapp $netapp -volumeName $volName -svmObj $svmObj `
@@ -773,7 +774,7 @@ try
             # 3. Politique de snapshot
 
             # Si volume collaboratif ET qu'il faut avoir les snapshots
-            if(( $volType -eq ([XaaSNASVolType]::col).ToString()) -and $snapPolicy -ne "")
+            if(( $volType -eq [XaaSNASVolType]::col) -and $snapPolicy -ne "")
             {
                 $snapPolicyObj = $netapp.getSnapshotPolicyByName($snapPolicy)
                 if($null -eq $snapPolicyObj)

--- a/powershell/xaas-nas-sync-webdav.ps1
+++ b/powershell/xaas-nas-sync-webdav.ps1
@@ -414,7 +414,7 @@ function handleNotifications
 try
 {
     
-    $logPath = @('xaas', 'nas', 'sync-webdav-{0}' -f $targetEnv.ToLower())
+    $logPath = @('xaas', 'nas', ('sync-webdav-{0}' -f $targetEnv.ToLower()))
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
     $logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 

--- a/powershell/xaas-nas-sync-webdav.ps1
+++ b/powershell/xaas-nas-sync-webdav.ps1
@@ -414,9 +414,9 @@ function handleNotifications
 try
 {
     
-    $logName = 'xaas-nas-sync-webdav-{0}' -f $targetEnv.ToLower()
+    $logPath = @('xaas', 'nas', 'sync-webdav-{0}' -f $targetEnv.ToLower())
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-s3-endpoint.ps1
+++ b/powershell/xaas-s3-endpoint.ps1
@@ -235,7 +235,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-s3', (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new(@('xaas', 's3', 'endpoint'), $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-sample-endpoint.ps1
+++ b/powershell/xaas-sample-endpoint.ps1
@@ -156,7 +156,7 @@ try
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
     # TODO: Adapter la ligne suivante
-    #$logHistory = [LogHistory]::new('xaas-s3', (Join-Path $PSScriptRoot "logs"), 30)
+    #$logHistory = [LogHistory]::new(@('xaas','s3', 'endpoint'), $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))


### PR DESCRIPTION
# PR Contenues
#205 - Gestion des noms "à double" pour les BG
#203 - Changement de la manière de choisir une SVM pour servir un volume applicatif
#213 - Réorganisation des fichiers logs

- Correction d'un bug dans l'effacement des vieux fichiers/dossiers de logs... 
- Ajout d'un filtre pour ne renvoyer que les images de backup faites avec une policy de type "VMware" lorsque l'on demande la liste des backups d'une VM donnée via le endpoint `xaas-backup-endpoint.ps1`

# Mise en production
- Désactiver la tâche planifiée pour concaténer les fichiers logs.