### PR TITLE
Reorganize logs

### DIFF
--- a/powershell/clean-ghost-bg.ps1
+++ b/powershell/clean-ghost-bg.ps1
@@ -355,7 +355,7 @@ try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
 	$logName = 'vra-clean-ghost-bg-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory =[LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+	$logHistory =[LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/clean-ghost-bg.ps1
+++ b/powershell/clean-ghost-bg.ps1
@@ -354,8 +354,8 @@ function handleNotifications
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logName = 'vra-clean-ghost-bg-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory =[LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
+	$logPath = @('vra', 'clean-ghost-bg-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logHistory =[LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/clean-iso-folders.ps1
+++ b/powershell/clean-iso-folders.ps1
@@ -105,7 +105,7 @@ try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
 	$logName = 'vra-Clean-ISO-Folders-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory =[LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+	$logHistory =[LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/clean-iso-folders.ps1
+++ b/powershell/clean-iso-folders.ps1
@@ -104,8 +104,8 @@ function Set-CDDriveAndAnswer
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logName = 'vra-Clean-ISO-Folders-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory =[LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
+	$logPath = @('vra', 'clean-iso-folders-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logHistory =[LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/include/LogHistory.inc.ps1
+++ b/powershell/include/LogHistory.inc.ps1
@@ -22,14 +22,15 @@ class LogHistory
               Le dossier créé portera le nom $logName et c'est dans celui-ci qu'on créera les fichiers logs,
               un par jour.
 
-        IN  : $logName          -> Nom du log
+        IN  : $logPath          -> Tableau avec le "chemin" jusqu'au log
         IN  : $rootFolderPath   -> Chemin jusqu'au dossier racine où mettre les logs.
         IN  : $nbDaysToKeep     -> Le nombre jours de profondeur que l'on veut garder
 	#>
-	LogHistory([string]$logName, [string]$rootFolderPath, [int]$nbDaysToKeep)
+	LogHistory([Array]$logPath, [string]$rootFolderPath, [int]$nbDaysToKeep)
 	{
         # On créé un dossier avec la date du jour pour le log
-        $this.logFolderPath = [IO.Path]::Combine($rootFolderPath, $logName, (Get-Date -format "yyyy-MM-dd"))
+        $cmd = '$this.logFolderPath = [IO.Path]::Combine($rootFolderPath, "{0}", (Get-Date -format "yyyy-MM-dd"))' -f ($logPath -join '","')
+        Invoke-Expression $cmd
         $this.logFilename = ("{0}.log" -f (Get-Date -Format "HH-mm-ss.fff"))
 
         # Si le dossier pour les logs n'existe pas encore,

--- a/powershell/mynas-process-hd-actions-requests.ps1
+++ b/powershell/mynas-process-hd-actions-requests.ps1
@@ -99,7 +99,7 @@ function setActionStatus
 try
 {
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-hd-actions', $global:LOGS_FOLDER, 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'process-hd-actions'), $global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-hd-actions-requests.ps1
+++ b/powershell/mynas-process-hd-actions-requests.ps1
@@ -99,7 +99,7 @@ function setActionStatus
 try
 {
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-hd-actions', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new('mynas-process-hd-actions', $global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-infos-from-cadi.ps1
+++ b/powershell/mynas-process-infos-from-cadi.ps1
@@ -83,7 +83,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-info-from-cadi',$global:LOGS_FOLDER, 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'process-info-from-cadi'), $global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-infos-from-cadi.ps1
+++ b/powershell/mynas-process-infos-from-cadi.ps1
@@ -83,7 +83,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-info-from-cadi', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new('mynas-process-info-from-cadi',$global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-user-delete-requests.ps1
+++ b/powershell/mynas-process-user-delete-requests.ps1
@@ -88,7 +88,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-user-delete', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new('mynas-process-user-delete', $global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-user-delete-requests.ps1
+++ b/powershell/mynas-process-user-delete-requests.ps1
@@ -88,7 +88,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-user-delete', $global:LOGS_FOLDER, 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'process-user-delete'), $global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-user-rename-requests.ps1
+++ b/powershell/mynas-process-user-rename-requests.ps1
@@ -181,7 +181,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-username-rename', $global:LOGS_FOLDER, 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'process-username-rename'), $global:LOGS_FOLDER, 30)
     
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-user-rename-requests.ps1
+++ b/powershell/mynas-process-user-rename-requests.ps1
@@ -181,7 +181,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-username-rename', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new('mynas-process-username-rename', $global:LOGS_FOLDER, 30)
     
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-waiting-quota-update-requests.ps1
+++ b/powershell/mynas-process-waiting-quota-update-requests.ps1
@@ -141,7 +141,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-quota-update', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new('mynas-process-quota-update', $global:LOGS_FOLDER, 30)
     
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-process-waiting-quota-update-requests.ps1
+++ b/powershell/mynas-process-waiting-quota-update-requests.ps1
@@ -141,7 +141,7 @@ try
 {
 
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-process-quota-update', $global:LOGS_FOLDER, 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'process-quota-update'), $global:LOGS_FOLDER, 30)
     
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-www-push-user-quota-usage.ps1
+++ b/powershell/mynas-www-push-user-quota-usage.ps1
@@ -157,7 +157,7 @@ function getFSNoFromUID
 try
 {
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-push-user-quota-usage', $global:LOGS_FOLDER, 30)
+   $logHistory = [LogHistory]::new(@('mynas', 'push-user-quota-usage'), $global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/mynas-www-push-user-quota-usage.ps1
+++ b/powershell/mynas-www-push-user-quota-usage.ps1
@@ -157,7 +157,7 @@ function getFSNoFromUID
 try
 {
    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-   $logHistory = [LogHistory]::new('mynas-push-user-quota-usage', (Join-Path $PSScriptRoot "logs"), 30)
+   $logHistory = [LogHistory]::new('mynas-push-user-quota-usage', $global:LOGS_FOLDER, 30)
 
    # Objet pour pouvoir envoyer des mails de notification
    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MYNAS_MAIL_TEMPLATE_FOLDER, $global:MYNAS_MAIL_SUBJECT_PREFIX, @{})

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -646,8 +646,8 @@ $RESEARCH_TEST_NB_PROJECTS_MAX = 5
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logName = 'vra-sync-AD-from-LDAP-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory = [LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
+	$logPath = @('vra', 'sync-AD-from-LDAP-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/sync-ad-groups-from-various.ps1
+++ b/powershell/sync-ad-groups-from-various.ps1
@@ -647,7 +647,7 @@ try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
 	$logName = 'vra-sync-AD-from-LDAP-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory = [LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+	$logHistory = [LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1343,8 +1343,8 @@ $global:existingADGroups = @()
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logName = 'vra-sync-BG-from-AD-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory =[LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
+	$logPath = @('vra', 'sync-BG-from-AD-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
+	$logHistory =[LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1344,7 +1344,7 @@ try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
 	$logName = 'vra-sync-BG-from-AD-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
-	$logHistory =[LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+	$logHistory =[LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
 
 	# On contrôle le prototype d'appel du script
 	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/vsphere-update-vm-notes.ps1
+++ b/powershell/vsphere-update-vm-notes.ps1
@@ -108,7 +108,7 @@ try
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
     $logName = 'vsphere-update-VM-notes-{0}' -f $targetEnv.ToLower()
-    $logHistory = [LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/vsphere-update-vm-notes.ps1
+++ b/powershell/vsphere-update-vm-notes.ps1
@@ -107,8 +107,8 @@ try
 {
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logName = 'vsphere-update-VM-notes-{0}' -f $targetEnv.ToLower()
-    $logHistory = [LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
+    $logPath = @('vsphere', 'update-VM-notes-{0}' -f $targetEnv.ToLower())
+    $logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-backup-endpoint.ps1
+++ b/powershell/xaas-backup-endpoint.ps1
@@ -111,7 +111,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-backup', $global:LOGS_FOLDER, 30)
+    $logHistory = [LogHistory]::new(@('xaas','backup', 'endpoint'), $global:LOGS_FOLDER, 30)
 
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-backup-endpoint.ps1
+++ b/powershell/xaas-backup-endpoint.ps1
@@ -111,7 +111,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-backup', (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new('xaas-backup', $global:LOGS_FOLDER, 30)
 
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-backup-sync-vm-tags.ps1
+++ b/powershell/xaas-backup-sync-vm-tags.ps1
@@ -89,7 +89,7 @@ try
 {
     $logName = 'xaas-backup-sync-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
 
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-backup-sync-vm-tags.ps1
+++ b/powershell/xaas-backup-sync-vm-tags.ps1
@@ -87,9 +87,9 @@ function backupTagRepresentation([string]$backupTag)
 
 try
 {
-    $logName = 'xaas-backup-sync-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()
+    $logPath = @('xaas', 'backup', 'sync-vm-tags-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower())
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
+    $logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-billing.ps1
+++ b/powershell/xaas-billing.ps1
@@ -215,7 +215,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-billing', $global:LOGS_FOLDER, 30)
+    $logHistory = [LogHistory]::new(@('xaas', 'billing'), $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-billing.ps1
+++ b/powershell/xaas-billing.ps1
@@ -215,7 +215,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-billing', (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new('xaas-billing', $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -485,7 +485,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-nas', $global:LOGS_FOLDER, 30)
+    $logHistory = [LogHistory]::new(@('xaas','nas', 'endpoint'), $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-nas-endpoint.ps1
+++ b/powershell/xaas-nas-endpoint.ps1
@@ -485,7 +485,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-nas', (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new('xaas-nas', $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-nas-sync-webdav.ps1
+++ b/powershell/xaas-nas-sync-webdav.ps1
@@ -416,7 +416,7 @@ try
     
     $logName = 'xaas-nas-sync-webdav-{0}' -f $targetEnv.ToLower()
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new($logName, (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
 
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-nas-sync-webdav.ps1
+++ b/powershell/xaas-nas-sync-webdav.ps1
@@ -414,9 +414,9 @@ function handleNotifications
 try
 {
     
-    $logName = 'xaas-nas-sync-webdav-{0}' -f $targetEnv.ToLower()
+    $logPath = @('xaas', 'nas', 'sync-webdav-{0}' -f $targetEnv.ToLower())
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new($logName, $global:LOGS_FOLDER, 30)
+    $logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 30)
 
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-s3-endpoint.ps1
+++ b/powershell/xaas-s3-endpoint.ps1
@@ -235,7 +235,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-s3', (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new('xaas-s3', $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-s3-endpoint.ps1
+++ b/powershell/xaas-s3-endpoint.ps1
@@ -235,7 +235,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-s3', $global:LOGS_FOLDER, 30)
+    $logHistory = [LogHistory]::new(@('xaas', 's3', 'endpoint'), $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-sample-endpoint.ps1
+++ b/powershell/xaas-sample-endpoint.ps1
@@ -156,7 +156,7 @@ try
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
     # TODO: Adapter la ligne suivante
-    #$logHistory = [LogHistory]::new('xaas-s3', $global:LOGS_FOLDER, 30)
+    #$logHistory = [LogHistory]::new(@('xaas','s3', 'endpoint'), $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))

--- a/powershell/xaas-sample-endpoint.ps1
+++ b/powershell/xaas-sample-endpoint.ps1
@@ -156,7 +156,7 @@ try
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
     # TODO: Adapter la ligne suivante
-    #$logHistory = [LogHistory]::new('xaas-s3', (Join-Path $PSScriptRoot "logs"), 30)
+    #$logHistory = [LogHistory]::new('xaas-s3', $global:LOGS_FOLDER, 30)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))


### PR DESCRIPTION
- Utilisation d'une constante `$global` pour déterminer le "root folder" des logs
- Ajout de la possibilité de mettre un `path` sous la forme de tableau pour les logs, afin de les réorganiser un peu niveau hiérarchie.
- Changement de la localisation des logs de tous les scripts
 
# Issues
#208 