### PR TITLE
REST base URL

### DIFF
--- a/powershell/include/REST/CopernicAPI.inc.ps1
+++ b/powershell/include/REST/CopernicAPI.inc.ps1
@@ -137,7 +137,7 @@ class CopernicAPI: RESTAPICurl
         # Pour le debug
         #$body | ConvertTo-JSON -Depth 20 | Out-file "D:\IDEVING\IaaS\git\xaas-admin\powershell\billing\JSON.json"
 
-        $uri = "https://{0}/RESTAdapter/api/sd/facture" -f $this.server
+        $uri = "{0}/RESTAdapter/api/sd/facture" -f $this.baseUrl
 
         # Exécution de la requête et transformation en objet
         $callRes = $this.callAPI($uri, "Post", $body) 

--- a/powershell/include/REST/CopernicAPI.inc.ps1
+++ b/powershell/include/REST/CopernicAPI.inc.ps1
@@ -27,7 +27,6 @@ class CopernicAPI: RESTAPICurl
 	#>
     CopernicAPI([string]$server, [string]$username, [string]$password): base($server)
     {
-        $this.server = $server
         $this.username = $username
         $this.password = $password
 

--- a/powershell/include/REST/GroupsAPI.inc.ps1
+++ b/powershell/include/REST/GroupsAPI.inc.ps1
@@ -53,7 +53,7 @@ class GroupsAPI: RESTAPICurl
     #>
     hidden [string] getBaseURI([string]$command)
     {
-        return ("https://{0}/cgi-bin/rwsgroups/{1}?app={2}&caller={3}" -f $this.server, $command, $this.appName, $this.callerSciper)
+        return ("{0}/cgi-bin/rwsgroups/{1}?app={2}&caller={3}" -f $this.baseUrl, $command, $this.appName, $this.callerSciper)
     }
 
 

--- a/powershell/include/REST/NSXAPI.inc.ps1
+++ b/powershell/include/REST/NSXAPI.inc.ps1
@@ -38,6 +38,9 @@ class NSXAPI: RESTAPICurl
 
         # Mise à jour des headers
         $this.headers.Add('Authorization', ("Remote {0}" -f $this.authInfos))
+
+        # Mise à jour de l'URL de base pour accéder à l'API
+        $this.baseUrl = "{0}/api/v1" -f $this.baseUrl
         
     }
 
@@ -60,7 +63,7 @@ class NSXAPI: RESTAPICurl
     #>
     [PSObject] getNSGroupById([string]$id)
     {
-        $uri = "https://{0}/api/v1/ns-groups/{1}" -f $this.server, $id
+        $uri = "{0}/ns-groups/{1}" -f $this.baseUrl, $id
 
         $nsGroup = $this.callAPI($uri, "Get", $null)
 
@@ -90,7 +93,7 @@ class NSXAPI: RESTAPICurl
     [PSObject] getNSGroupByName([string]$name)
     {
         # Note: On filtre exprès avec 'member_types=VirtualMachine' car sinon tous les NSGroup attendus ne sont pas renvoyés... 
-        $uri = "https://{0}/api/v1/ns-groups/?populate_references=false&member_types=VirtualMachine" -f $this.server
+        $uri = "{0}/ns-groups/?populate_references=false&member_types=VirtualMachine" -f $this.baseUrl
 
         $id =  ($this.callAPI($uri, "Get", $null).results | Where-Object {$_.display_name -eq $name}).id
      
@@ -121,7 +124,7 @@ class NSXAPI: RESTAPICurl
 	#>
     [PSObject] addNSGroup([string]$name, [string]$desc, [string] $tag)
     {
-		$uri = "https://{0}/api/v1/ns-groups" -f $this.server
+		$uri = "{0}/ns-groups" -f $this.baseUrl
 
 		# Valeur à mettre pour la configuration du NS Group
 		$replace = @{name = $name
@@ -146,7 +149,7 @@ class NSXAPI: RESTAPICurl
 	#>
     [void] deleteNSGroup([PSObject]$nsGroup)
     {
-        $uri = "https://{0}/api/v1/ns-groups/{1}" -f $this.server, $nsGroup.id
+        $uri = "{0}/ns-groups/{1}" -f $this.baseUrl, $nsGroup.id
 
         $this.callAPI($uri, "Delete", $null) | Out-Null
     }
@@ -193,7 +196,7 @@ class NSXAPI: RESTAPICurl
             $type = "LAYER3"
         }
 
-		$uri = "https://{0}/api/v1/firewall/sections?filter_type={1}&page_size=1000&search_invalid_references=false&type={2}" -f $this.server, $filterType, $type
+		$uri = "{0}/firewall/sections?filter_type={1}&page_size=1000&search_invalid_references=false&type={2}" -f $this.baseUrl, $filterType, $type
 
         # Récupération de la liste
 		$sectionList = $this.callAPI($uri, "GET", $null).results
@@ -233,7 +236,7 @@ class NSXAPI: RESTAPICurl
 	#>
     [psObject] getFirewallSectionById([string] $id)
     {
-        $uri = "https://{0}/api/v1/firewall/sections/{1}" -f $this.server, $id
+        $uri = "{0}/firewall/sections/{1}" -f $this.baseUrl, $id
 
         # Création du NSGroup
 		return $this.callAPI($uri, "GET", $null)
@@ -255,7 +258,7 @@ class NSXAPI: RESTAPICurl
     [PSObject] addFirewallSection([string]$name, [string]$desc, [string]$beforeId, [PSObject]$nsGroup)
     {
         
-        $uri = "https://{0}/api/v1/firewall/sections" -f $this.server
+        $uri = "{0}/firewall/sections" -f $this.baseUrl
         
         # Si on doit insérer avant un ID donné
         if($beforeId -ne "")
@@ -289,7 +292,7 @@ class NSXAPI: RESTAPICurl
     [void] updateFirewallSection([PSObject]$section)
     {
         
-        $uri = "https://{0}/api/v1/firewall/sections/{1}" -f $this.server, $section.id
+        $uri = "{0}/firewall/sections/{1}" -f $this.baseUrl, $section.id
         
 		# Création de la section de firewall
         $this.callAPI($uri, "PUT", $section) | Out-Null
@@ -306,7 +309,7 @@ class NSXAPI: RESTAPICurl
     [void] deleteFirewallSection([string]$id)
     {
         
-        $uri = "https://{0}/api/v1/firewall/sections/{1}?cascade=true" -f $this.server, $id
+        $uri = "{0}/firewall/sections/{1}?cascade=true" -f $this.baseUrl, $id
         
 		# Création de la section de firewall
         $this.callAPI($uri, "Delete", $null) | Out-Null
@@ -339,7 +342,7 @@ class NSXAPI: RESTAPICurl
         }
 
         # Ensuite on va la modifier en prenant soin de mettre le bon no de révision 
-        $uri = "https://{0}/api/v1/firewall/sections/{1}?action=lock" -f $this.server, $id
+        $uri = "{0}/firewall/sections/{1}?action=lock" -f $this.baseUrl, $id
 
 
         # Valeur à mettre pour la configuration de la section de firewall
@@ -371,7 +374,7 @@ class NSXAPI: RESTAPICurl
     #>
     [Array] getFirewallSectionRules([string]$firewallSectionId)
     {
-        $uri = "https://{0}/api/v1/firewall/sections/{1}/rules" -f $this.server, $firewallSectionId
+        $uri = "{0}/firewall/sections/{1}/rules" -f $this.baseUrl, $firewallSectionId
 
         return $this.callAPI($uri, "GET", $null).results
     }
@@ -393,7 +396,7 @@ class NSXAPI: RESTAPICurl
     #>
     [void] addFirewallSectionRules([string]$firewallSectionId, [Hashtable]$ruleIn, [Hashtable]$ruleComm, [Hashtable]$ruleOut, [hashtable]$ruleDeny, [PSObject]$nsGroup)
     {
-        $uri = "https://{0}/api/v1/firewall/sections/{1}/rules?action=create_multiple" -f $this.server, $firewallSectionId
+        $uri = "{0}/firewall/sections/{1}/rules?action=create_multiple" -f $this.baseUrl, $firewallSectionId
 
 		# Valeur à mettre pour la configuration des règles
         $replace = @{ruleNameIn             = $ruleIn.name

--- a/powershell/include/REST/RESTAPI.inc.ps1
+++ b/powershell/include/REST/RESTAPI.inc.ps1
@@ -21,7 +21,6 @@
 #>
 class RESTAPI: APIUtils
 {
-	hidden [string]$server
 	hidden [string]$baseUrl
 	hidden [System.Collections.Hashtable]$headers
 	hidden [System.Object] $lastBody
@@ -34,9 +33,8 @@ class RESTAPI: APIUtils
 	#>
     RESTAPI([string] $server)
     {
-		$this.server = $server
 		$this.headers = @{}
-		$this.baseUrl = "https://{0}" -f $this.server
+		$this.baseUrl = "https://{0}" -f $server
     }
 
 

--- a/powershell/include/REST/RESTAPI.inc.ps1
+++ b/powershell/include/REST/RESTAPI.inc.ps1
@@ -22,6 +22,7 @@
 class RESTAPI: APIUtils
 {
 	hidden [string]$server
+	hidden [string]$baseUrl
 	hidden [System.Collections.Hashtable]$headers
 	hidden [System.Object] $lastBody
 
@@ -35,6 +36,7 @@ class RESTAPI: APIUtils
     {
 		$this.server = $server
 		$this.headers = @{}
+		$this.baseUrl = "https://{0}" -f $this.server
     }
 
 

--- a/powershell/include/REST/XaaS/Backup/NetBackupAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/Backup/NetBackupAPI.inc.ps1
@@ -53,8 +53,7 @@ class NetBackupAPI: RESTAPICurl
 	#>
 	NetBackupAPI([string] $server, [string] $user, [string] $password) : base($server) # Ceci appelle le constructeur parent
 	{
-		$this.server = $server
-
+		
 		<# Le plus souvent, on utilise 'application/json' pour les 'Accept' et 'Content-Type' mais NetBackup semble vouloir faire
 			autrement... du coup, obligé de mettre ceci car sinon cela génère des erreurs. Et au final, c'est toujours du JSON... #>
 		$this.headers.Add('Accept', 'application/vnd.netbackup+json;version=2.0')

--- a/powershell/include/REST/XaaS/Backup/NetBackupAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/Backup/NetBackupAPI.inc.ps1
@@ -65,7 +65,7 @@ class NetBackupAPI: RESTAPICurl
 		$body = @{userName = $user
 					password = $password}
 
-		$uri = "https://{0}/login" -f $this.server
+		$uri = "{0}/login" -f $this.baseUrl
 
 		# Pour autoriser les certificats self-signed
 		[System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $True }
@@ -128,7 +128,7 @@ class NetBackupAPI: RESTAPICurl
 	#>
 	[Void] disconnect()
 	{
-		$uri = "https://{0}/logout" -f $this.server
+		$uri = "{0}/logout" -f $this.baseUrl
 
 		$this.callAPI($uri, "Post", $null)
     }
@@ -156,7 +156,7 @@ class NetBackupAPI: RESTAPICurl
 
 		$pagination =  [System.Net.WebUtility]::UrlEncode("page[offset]=0&page[limit]={0}&" -f $global:NETBACKUP_API_PAGE_LIMIT_MAX)
 
-		$uri = "https://{0}/catalog/images?filter=clientName eq '{1}' and backupTime ge {2}&{3}" -f $this.server, $vmName, $dateAgo, $pagination
+		$uri = "{0}/catalog/images?filter=clientName eq '{1}' and backupTime ge {2}&{3}" -f $this.baseUrl, $vmName, $dateAgo, $pagination
 
 		
 
@@ -180,7 +180,7 @@ class NetBackupAPI: RESTAPICurl
     #>
     [PSObject] restoreVM([string]$vmName, [string]$backupId, [string]$backupTimestamp)
     {
-        $uri = "https://{0}/recovery/workloads/vmware/scenarios/full-vm/recover" -f $this.server
+        $uri = "{0}/recovery/workloads/vmware/scenarios/full-vm/recover" -f $this.baseUrl
 
 		# Si c'est le timestamp qui a été donné, 
 		if($backupId -eq "")
@@ -225,7 +225,7 @@ class NetBackupAPI: RESTAPICurl
     [PSCustomObject] getJobDetails([string]$jobId)
     {
 
-		$uri = "https://{0}/admin/jobs/{1}" -f $this.server, $jobId
+		$uri = "{0}/admin/jobs/{1}" -f $this.baseUrl, $jobId
 
 		$res = ($this.callAPI($uri, "Get", $null))
 

--- a/powershell/include/REST/XaaS/S3/ScalityWebConsoleAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/S3/ScalityWebConsoleAPI.inc.ps1
@@ -41,8 +41,10 @@ class ScalityWebConsoleAPI: RESTAPICurl
         # un fichier JSON dans les templates pour quelque chose de simple comme ça.
         $body = @{username = $username
                     password = $password}
+        
+        $this.baseUrl = "{0}/_/console" -f $this.baseUrl
 
-        $uri = "https://{0}/_/console/authenticate" -f $this.server
+        $uri = "{0}/authenticate" -f $this.baseUrl
 
         $result = $this.callAPI($uri, "Post",  $body)
         
@@ -84,7 +86,7 @@ class ScalityWebConsoleAPI: RESTAPICurl
     #>
     [PSObject]getPolicyContent([string]$policyArn, [string]$policyVersion)
     {
-        $uri = "https://{0}/_/console/iam/getpolicyversion" -f $this.server
+        $uri = "{0}/iam/getpolicyversion" -f $this.baseUrl
 
         $body = @{policyArn = $policyArn
                 policyVersion = $policyVersion}
@@ -150,7 +152,7 @@ class ScalityWebConsoleAPI: RESTAPICurl
     #>
     [PSObject]getBucketUsageInfos([string]$bucketName)
     {
-        $uri = "https://{0}/_/console/utapi/buckets" -f $this.server
+        $uri = "{0}/utapi/buckets" -f $this.baseUrl
 
         <# Documentation donnée pour l'appel à l'API dans le cas où on donnerait un "timeRange" incorrect:
         

--- a/powershell/include/REST/XaaS/S3/ScalityWebConsoleAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/S3/ScalityWebConsoleAPI.inc.ps1
@@ -31,8 +31,7 @@ class ScalityWebConsoleAPI: RESTAPICurl
 	#>
 	ScalityWebConsoleAPI([string]$server, [string]$username, [string]$password) : base($server) # Ceci appelle le constructeur parent
 	{
-        $this.server = $server
-
+        
         $this.headers = @{}
 		$this.headers.Add('Accept', 'application/json')
         $this.headers.Add('Content-Type', 'application/json')

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -42,7 +42,6 @@ class vRAAPI: RESTAPICurl
 	#>
 	vRAAPI([string] $server, [string] $tenant, [string] $userAtDomain, [string] $password) : base($server) # Ceci appelle le constructeur parent
 	{
-		$this.server = $server
 		$this.tenant = $tenant
 
 		# Cache pour le mapping entre l'ID custom d'un BG et celui-ci

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -57,7 +57,7 @@ class vRAAPI: RESTAPICurl
 
 		$body = $this.createObjectFromJSON("vra-user-credentials.json", $replace)
 
-		$uri = "https://{0}/identity/api/tokens" -f $this.server
+		$uri = "{0}/identity/api/tokens" -f $this.baseUrl
 
 		# Pour autoriser les certificats self-signed
 		[System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $True }
@@ -107,7 +107,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[Void] disconnect()
 	{
-		$uri = "https://{0}/identity/api/tokens/{1}" -f $this.server, $this.token
+		$uri = "{0}/identity/api/tokens/{1}" -f $this.baseUrl, $this.token
 
 		$this.callAPI($uri, "Delete", $null)
 	}
@@ -135,7 +135,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getBGListQuery([string] $queryParams)
 	{
-		$uri = "https://{0}/identity/api/tenants/{1}/subtenants/?page=1&limit=9999" -f $this.server, $this.tenant
+		$uri = "{0}/identity/api/tenants/{1}/subtenants/?page=1&limit=9999" -f $this.baseUrl, $this.tenant
 
 		# Si on doit ajouter des paramètres
 		if($queryParams -ne "")
@@ -280,7 +280,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[PSCustomObject] addBG([string]$name, [string]$desc, [string]$capacityAlertsEmail, [string]$machinePrefixId, [System.Collections.Hashtable] $customProperties)
 	{
-		$uri = "https://{0}/identity/api/tenants/{1}/subtenants" -f $this.server, $this.tenant
+		$uri = "{0}/identity/api/tenants/{1}/subtenants" -f $this.baseUrl, $this.tenant
 
 		# Valeur à mettre pour la configuration du BG
 		$replace = @{name = $name
@@ -340,7 +340,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[PSCustomObject] updateBG([PSCustomObject] $bg, [string] $newName, [string] $newDesc, [string]$machinePrefixId, [System.Collections.IDictionary]$customProperties)
 	{
-		$uri = "https://{0}/identity/api/tenants/{1}/subtenants/{2}" -f $this.server, $this.tenant, $bg.id
+		$uri = "{0}/identity/api/tenants/{1}/subtenants/{2}" -f $this.baseUrl, $this.tenant, $bg.id
 
 		$updateNeeded = $false
 
@@ -437,7 +437,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[PSCustomObject] deleteBGCustomProperty([PSCustomObject]$bg, [string]$customPropertyName)
 	{
-		$uri = "https://{0}/identity/api/tenants/{1}/subtenants/{2}" -f $this.server, $this.tenant, $bg.id
+		$uri = "{0}/identity/api/tenants/{1}/subtenants/{2}" -f $this.baseUrl, $this.tenant, $bg.id
 
 		# Filtrage de la custom property à supprimer
 		$entries = $bg.extensionData.entries | Where-Object {$_.key -ne $customPropertyName}
@@ -467,7 +467,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[void] deleteBG($bgId)
 	{
-		$uri = "https://{0}/identity/api/tenants/{1}/subtenants/{2}" -f $this.server, $this.tenant, $bgId
+		$uri = "{0}/identity/api/tenants/{1}/subtenants/{2}" -f $this.baseUrl, $this.tenant, $bgId
 
 		# Mise à jour des informations
 		$this.callAPI($uri, "Delete", $null) | Out-Null
@@ -497,7 +497,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[Array] getBGRoleContent([string] $BGID, [string] $role)
 	{
-		$uri = "https://{0}/identity/api/tenants/{1}/subtenants/{2}/roles/{3}/principals/" -f $this.server, $this.tenant, $BGID, $role
+		$uri = "{0}/identity/api/tenants/{1}/subtenants/{2}/roles/{3}/principals/" -f $this.baseUrl, $this.tenant, $BGID, $role
 
 		# Récupération de la liste d'objets
 		$res = ($this.callAPI($uri, "Get", $null)).content
@@ -525,7 +525,7 @@ class vRAAPI: RESTAPICurl
 		# S'il y a du contenu pour le rôle
 		if(($this.getBGRoleContent($BGID, $role)).count -gt 0)
 		{
-			$uri = "https://{0}/identity/api/tenants/{1}/subtenants/{2}/roles/{3}/" -f $this.server, $this.tenant, $BGID, $role
+			$uri = "{0}/identity/api/tenants/{1}/subtenants/{2}/roles/{3}/" -f $this.baseUrl, $this.tenant, $BGID, $role
 
 			# Suppression du contenu du rôle
 			$this.callAPI($uri, "Delete", $null) | Out-Null
@@ -554,7 +554,7 @@ class vRAAPI: RESTAPICurl
 		# Séparation des informations
 		$userOrGroup, $domain = $userOrGroupAtDomain.split('@')
 
-		$uri = "https://{0}/identity/api/tenants/{1}/subtenants/{2}/roles/{3}/principals" -f $this.server, $this.tenant, $BGID, $role
+		$uri = "{0}/identity/api/tenants/{1}/subtenants/{2}/roles/{3}/principals" -f $this.baseUrl, $this.tenant, $BGID, $role
 
 
 		# ******
@@ -609,7 +609,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getEntListQuery([string] $queryParams)
 	{
-		$uri = "https://{0}/catalog-service/api/entitlements/?page=1&limit=9999" -f $this.server
+		$uri = "{0}/catalog-service/api/entitlements/?page=1&limit=9999" -f $this.baseUrl
 
 		# Si un filtre a été passé, on l'ajoute
 		if($queryParams -ne "")
@@ -635,7 +635,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[PSCustomObject] getBGEnt([string]$BGID)
 	{
-		$uri = "https://{0}/catalog-service/api/entitlements/?page=1&limit=9999&`$filter=organization/subTenant/id eq '{1}'" -f $this.server, $BGID
+		$uri = "{0}/catalog-service/api/entitlements/?page=1&limit=9999&`$filter=organization/subTenant/id eq '{1}'" -f $this.baseUrl, $BGID
 
 		$ent = ($this.callAPI($uri, "Get", $null)).content
 
@@ -703,7 +703,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[PSCustomObject] addEnt([string]$name, [string]$desc, [string]$BGID, [string]$bgName)
 	{
-		$uri = "https://{0}/catalog-service/api/entitlements" -f $this.server
+		$uri = "{0}/catalog-service/api/entitlements" -f $this.baseUrl
 
 		# Valeur à mettre pour la configuration du BG
 		$replace = @{name = $name
@@ -743,7 +743,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[PSCustomObject] updateEnt([PSCustomObject] $ent, [string] $newName, [string] $newDesc, [bool]$activated)
 	{
-		$uri = "https://{0}/catalog-service/api/entitlements/{1}" -f $this.server, $ent.id
+		$uri = "{0}/catalog-service/api/entitlements/{1}" -f $this.baseUrl, $ent.id
 
 
 		# S'il faut mettre le nom à jour,
@@ -814,7 +814,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[void] deleteEnt([string]$entID)
 	{
-		$uri = "https://{0}/catalog-service/api/entitlements/{1}" -f $this.server, $entId
+		$uri = "{0}/catalog-service/api/entitlements/{1}" -f $this.baseUrl, $entId
 
 		$this.callAPI($uri, "Delete", $null) | Out-Null
 	}
@@ -839,7 +839,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getServiceListQuery([string] $queryParams)
 	{
-		$uri = "https://{0}/catalog-service/api/services/?page=1&limit=9999" -f $this.server
+		$uri = "{0}/catalog-service/api/services/?page=1&limit=9999" -f $this.baseUrl
 
 		# Si un filtre a été passé, on l'ajoute
 		if($queryParams -ne "")
@@ -1095,7 +1095,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getResListQuery([string] $queryParams, [bool]$allowCache)
 	{
-		$uri = "https://{0}/reservation-service/api/reservations/?page=1&limit=9999" -f $this.server
+		$uri = "{0}/reservation-service/api/reservations/?page=1&limit=9999" -f $this.baseUrl
 
 		# Si un filtre a été passé, on l'ajoute
 		if($queryParams -ne "")
@@ -1177,7 +1177,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[PSCustomObject] addResFromTemplate([PSCustomObject]$resTemplate, [string]$name, [string]$tenant, [string]$BGID)
 	{
-		$uri = "https://{0}/reservation-service/api/reservations" -f $this.server
+		$uri = "{0}/reservation-service/api/reservations" -f $this.baseUrl
 
 		# Mise à jour des champs pour pouvoir ajouter la nouvelle Reservation
 		$resTemplate.name = $name
@@ -1214,7 +1214,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[Array] updateRes([PSCustomObject]$res, [PSCustomObject]$resTemplate, [string]$name)
 	{
-		$uri = "https://{0}/reservation-service/api/reservations/{1}" -f $this.server, $res.id
+		$uri = "{0}/reservation-service/api/reservations/{1}" -f $this.baseUrl, $res.id
 
 		$updated = $false
 
@@ -1249,7 +1249,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[void] deleteRes([string]$resID)
 	{
-		$uri = "https://{0}/reservation-service/api/reservations/{1}" -f $this.server, $resID
+		$uri = "{0}/reservation-service/api/reservations/{1}" -f $this.baseUrl, $resID
 
 		$this.callAPI($uri, "Delete", $null) | Out-Null
 		
@@ -1275,7 +1275,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getActionListQuery([string] $queryParams)
 	{
-		$uri = "https://{0}/catalog-service/api/resourceOperations/?page=1&limit=9999" -f $this.server
+		$uri = "{0}/catalog-service/api/resourceOperations/?page=1&limit=9999" -f $this.baseUrl
 
 		# Si un filtre a été passé, on l'ajoute
 		if($queryParams -ne "")
@@ -1360,7 +1360,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getPrincipalsListQuery([string] $queryParams)
 	{
-		$uri = "https://{0}/identity/api/authorization/tenants/{1}/principals/?page=1&limit=9999" -f $this.server, $this.tenant
+		$uri = "{0}/identity/api/authorization/tenants/{1}/principals/?page=1&limit=9999" -f $this.baseUrl, $this.tenant
 
 		# Si un filtre a été passé, on l'ajoute
 		if($queryParams -ne "")
@@ -1436,7 +1436,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getMachinePrefixListQuery([string] $queryParams)
 	{
-		$uri = "https://{0}/iaas-proxy-provider/api/machine-prefixes/?page=1&limit=9999" -f $this.server
+		$uri = "{0}/iaas-proxy-provider/api/machine-prefixes/?page=1&limit=9999" -f $this.baseUrl
 
 		# Si un filtre a été passé, on l'ajoute
 		if($queryParams -ne "")
@@ -1486,7 +1486,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[PSCustomObject] addMachinePrefix([string] $name, [int] $numberOfDigits)
 	{
-		$uri = "https://{0}/iaas-proxy-provider/api/machine-prefixes/" -f $this.server
+		$uri = "{0}/iaas-proxy-provider/api/machine-prefixes/" -f $this.baseUrl
 
 		# Valeur à mettre pour la configuration du BG
 		$replace = @{
@@ -1513,7 +1513,7 @@ class vRAAPI: RESTAPICurl
 			sa documentation). Bref, c'est grâce à ce post d'un forum que la solution a été trouvée:
 			https://communities.vmware.com/thread/604831
 		#>
-		$uri = "https://{0}/iaas-proxy-provider/api/machine-prefixes/guid'{1}'" -f $this.server, $machinePrefix.id
+		$uri = "{0}/iaas-proxy-provider/api/machine-prefixes/guid'{1}'" -f $this.baseUrl, $machinePrefix.id
 
 		$this.callAPI($uri, "DELETE", $null) | Out-Null
 	}
@@ -1539,7 +1539,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getEntitledCatalogItemListQuery([string] $queryParams)
 	{
-		$uri = "https://{0}/catalog-service/api/consumer/entitledCatalogItems/?page=1&limit=5000" -f $this.server
+		$uri = "{0}/catalog-service/api/consumer/entitledCatalogItems/?page=1&limit=5000" -f $this.baseUrl
 
 		# Si un filtre a été passé, on l'ajoute
 		if($queryParams -ne "")
@@ -1567,7 +1567,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getCatalogItemListQuery([string] $queryParams)
 	{
-		$uri = "https://{0}/catalog-service/api/catalogItems/?page=1&limit=5000" -f $this.server
+		$uri = "{0}/catalog-service/api/catalogItems/?page=1&limit=5000" -f $this.baseUrl
 
 		# Si un filtre a été passé, on l'ajoute
 		if($queryParams -ne "")
@@ -1639,7 +1639,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getBGItemListQuery([string] $queryParams)
 	{
-		$uri = "https://{0}/catalog-service/api/consumer/resources/?page=1&limit=9999" -f $this.server
+		$uri = "{0}/catalog-service/api/consumer/resources/?page=1&limit=9999" -f $this.baseUrl
 
 		# Si un filtre a été passé, on l'ajoute
 		if($queryParams -ne "")
@@ -1748,7 +1748,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[void] syncDirectory([string] $name)
 	{
-		$uri = "https://{0}/identity/api/tenants/{1}/directories/{2}/sync" -f $this.server, $this.tenant, $name
+		$uri = "{0}/identity/api/tenants/{1}/directories/{2}/sync" -f $this.baseUrl, $this.tenant, $name
 
 		$this.callAPI($uri, "Post", $null) | Out-Null
 	}
@@ -1774,7 +1774,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	hidden [Array] getApprovePolicyListQuery([string] $queryParams)
 	{
-		$uri = "https://{0}/approval-service/api/policies?page=1&limit=9999" -f $this.server
+		$uri = "{0}/approval-service/api/policies?page=1&limit=9999" -f $this.baseUrl
 
 		# Si on doit ajouter des paramètres
 		if($queryParams -ne "")
@@ -1841,7 +1841,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[psobject] addPreApprovalPolicy([string]$name, [string]$desc, [string]$approvalLevelJSON, [Array]$approverGroupAtDomainList, [string]$approvalPolicyJSON, [psobject]$additionnalReplace)
 	{
-		$uri = "https://{0}/approval-service/api/policies" -f $this.server
+		$uri = "{0}/approval-service/api/policies" -f $this.baseUrl
 
 		# Création des approval levels
 		$approvalLevels = @()
@@ -1897,7 +1897,7 @@ class vRAAPI: RESTAPICurl
 	#>
 	[psobject] setApprovalPolicyState([PSCustomObject]$approvalPolicy, [bool]$activated)
 	{
-		$uri = "https://{0}/approval-service/api/policies/{1}" -f $this.server, $approvalPolicy.id
+		$uri = "{0}/approval-service/api/policies/{1}" -f $this.baseUrl, $approvalPolicy.id
 
 		# Si la policy est par hasard en "DRAFT", on ne fait rien
 		if($approvalPolicy.state -eq "DRAFT")
@@ -1951,7 +1951,7 @@ class vRAAPI: RESTAPICurl
 		# On commence par la désactiver sinon on ne pourra pas la supprimer
 		$approvalPolicy = $this.setApprovalPolicyState($approvalPolicy, $false)
 
-		$uri = "https://{0}/approval-service/api/policies/{1}" -f $this.server, $approvalPolicy.id
+		$uri = "{0}/approval-service/api/policies/{1}" -f $this.baseUrl, $approvalPolicy.id
 
 		# Mise à jour des informations
 		$this.callAPI($uri, "Delete", $null) | Out-Null
@@ -1977,7 +1977,7 @@ class vRAAPI: RESTAPICurl
 	[Array] getResourceActionList([PSCustomObject]$forResource)
 	{
 		
-		$uri = "https://{0}/catalog-service/api/consumer/resources/{1}/actions" -f $this.server, $forResource.id
+		$uri = "{0}/catalog-service/api/consumer/resources/{1}/actions" -f $this.baseUrl, $forResource.id
 
 		# Retour de la liste
 		return $this.callAPI($uri, "Get", $null).content
@@ -2025,7 +2025,7 @@ class vRAAPI: RESTAPICurl
 		}
 
 		# URL de recherche du template pour l'action que l'on désire effectuer
-		$uri = "https://{0}/catalog-service/api/consumer/resources/{1}/actions/{2}/requests/template/" -f $this.server, $forResource.id, $actionInfos.id
+		$uri = "{0}/catalog-service/api/consumer/resources/{1}/actions/{2}/requests/template/" -f $this.baseUrl, $forResource.id, $actionInfos.id
 
 		return $this.callAPI($uri, "Get", $null)
 	}
@@ -2082,7 +2082,7 @@ class vRAAPI: RESTAPICurl
 		}
 
 
-		$uri = "https://{0}/catalog-service/api/consumer/resources/{1}/actions/{2}/requests" -f $this.server, $actionTemplate.resourceId, $actionTemplate.actionId
+		$uri = "{0}/catalog-service/api/consumer/resources/{1}/actions/{2}/requests" -f $this.baseUrl, $actionTemplate.resourceId, $actionTemplate.actionId
 
 		# Mise à jour de la description, bien qu'elle n'apparaîtra nulle part...
 		$actionTemplate.description = "Automatic Backup Tag Update"

--- a/powershell/include/REST/vROAPI.inc.ps1
+++ b/powershell/include/REST/vROAPI.inc.ps1
@@ -45,7 +45,7 @@ class vROAPI
 
 		$body = "username=administrator&password={0}&client_id={1}&domain={2}" -f $password, $cafeClientID, $this.tenant
 
-		$uri = "https://{0}/SAAS/t/{1}/auth/oauthtoken?grant_type=password" -f $this.server, $this.tenant
+		$uri = "https://{0}/SAAS/t/{1}/auth/oauthtoken?grant_type=password" -f $server, $this.tenant
 
 		# Pour autoriser les certificats self-signed
 		[System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $True }

--- a/powershell/include/REST/vSphereAPI.inc.ps1
+++ b/powershell/include/REST/vSphereAPI.inc.ps1
@@ -51,7 +51,8 @@ class vSphereAPI: RESTAPICurl
 		# Mise à jour des headers
 		$this.headers.Add('Authorization', ("Basic {0}" -f $authInfos))
 
-		$uri = "https://{0}/rest/com/vmware/cis/session" -f $this.server
+		$this.baseUrl = "{0}/rest" -f $this.baseUrl
+		$uri = "{0}/com/vmware/cis/session" -f $this.baseUrl
 
 		# Pour autoriser les certificats self-signed
 		[System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $True }
@@ -73,7 +74,7 @@ class vSphereAPI: RESTAPICurl
 	#>
 	[Void] disconnect()
 	{
-		$uri = "https://{0}/rest/com/vmware/cis/session" -f $this.server
+		$uri = "{0}/com/vmware/cis/session" -f $this.baseUrl
 
 		$this.callAPI($uri, "Delete", $null)
 	}    
@@ -91,7 +92,7 @@ class vSphereAPI: RESTAPICurl
 	#>
 	hidden [PSObject] getVM([string] $vmName)
 	{
-		$uri = "https://{0}/rest/vcenter/vm?filter.names={1}" -f $this.server, $vmName
+		$uri = "{0}/vcenter/vm?filter.names={1}" -f $this.baseUrl, $vmName
 		return ($this.callAPI($uri, "Get", $null)).value[0]
 	}
 
@@ -105,7 +106,7 @@ class vSphereAPI: RESTAPICurl
 	#>
 	hidden [PSObject] getTagById([string] $tagId)
 	{
-		$uri = "https://{0}/rest/com/vmware/cis/tagging/tag/id:{1}" -f $this.server, $tagId
+		$uri = "{0}/com/vmware/cis/tagging/tag/id:{1}" -f $this.baseUrl, $tagId
 		return ($this.callAPI($uri, "Get", $null)).value
 	}
 	
@@ -119,7 +120,7 @@ class vSphereAPI: RESTAPICurl
 	#>
 	hidden [PSObject] getCategoryById([string] $categoryId)
 	{
-		$uri = "https://{0}/rest/com/vmware/cis/tagging/category/id:{1}" -f $this.server, $categoryId
+		$uri = "{0}/com/vmware/cis/tagging/category/id:{1}" -f $this.baseUrl, $categoryId
 		return ($this.callAPI($uri, "Get", $null)).value
 	}
 
@@ -167,7 +168,7 @@ class vSphereAPI: RESTAPICurl
 		}
 
 
-		$uri = "https://{0}/rest/com/vmware/cis/tagging/tag-association/id:{1}?~action={2}" -f $this.server, $tag.id, $action
+		$uri = "{0}/com/vmware/cis/tagging/tag-association/id:{1}?~action={2}" -f $this.baseUrl, $tag.id, $action
 
 		$replace = @{tagId = $tag.id
 					objectType = "VirtualMachine"
@@ -272,7 +273,7 @@ class vSphereAPI: RESTAPICurl
     [Array] getVMTags([psobject] $vm)
     {
 
-		$uri = "https://{0}/rest/com/vmware/cis/tagging/tag-association?~action=list-attached-tags" -f $this.server
+		$uri = "{0}/com/vmware/cis/tagging/tag-association?~action=list-attached-tags" -f $this.baseUrl
 
 		$replace = @{objectType = "VirtualMachine"
 					objectId = $vm.vm}
@@ -317,7 +318,7 @@ class vSphereAPI: RESTAPICurl
 	#>
 	[Array] getTagList()
 	{
-		$uri = "https://{0}/rest/com/vmware/cis/tagging/tag" -f $this.server
+		$uri = "{0}/com/vmware/cis/tagging/tag" -f $this.baseUrl
 
 		return $this.callAPI($uri, "Get", $null).value
 	}
@@ -328,7 +329,7 @@ class vSphereAPI: RESTAPICurl
 	#>
 	[Array] getCategoryList()
 	{
-		$uri = "https://{0}/rest/com/vmware/cis/tagging/category" -f $this.server
+		$uri = "{0}/com/vmware/cis/tagging/category" -f $this.baseUrl
 
 		return $this.callAPI($uri, "Get", $null).value
 	}
@@ -341,7 +342,7 @@ class vSphereAPI: RESTAPICurl
 	#>
 	[Array] getTagList([string]$categoryName)
 	{
-		$uri = "https://{0}/rest/com/vmware/cis/tagging/tag" -f $this.server
+		$uri = "{0}/com/vmware/cis/tagging/tag" -f $this.baseUrl
 
 		return $this.callAPI($uri, "Get", $null).value
 	}


### PR DESCRIPTION
Changement de la manière de fonctionner pour les classes qui font des appels REST pour ne plus utiliser `$this.server` mais avoir un `$this.baseUrl`, ce qui simplifie un peu plus les choses pour la création des URL dans chaque fonction de chaque classe.
Cette manière de faire a été utilisée pour la création de la PR #214 et ensuite transposées aux autres classes.

# Issues
#215