### PR TITLE
BG name already taken when creating a new one

### DIFF
--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -17,11 +17,8 @@
 	Une description des fichiers JSON utilisés peut être trouvée sur Confluence.
 	https://sico.epfl.ch:8443/display/SIAC/Ressources+-+PRJ0011976#Ressources-PRJ0011976-vRA
 
-   ----------
-   HISTORIQUE DES VERSIONS
-   0.1 - Version de base
-   0.2 - Ajout d'un cache pour certaines fonctions qui ne sont appelées sur des objets qui 
-		 restent en lecture seule (donc pas modifiés par le script)
+	https://code.vmware.com/apis/39/vrealize-automation?p=vrealize-automation
+
 
 #>
 class vRAAPI: RESTAPICurl

--- a/powershell/resources/mail-templates/bg-create-duplicate.html
+++ b/powershell/resources/mail-templates/bg-create-duplicate.html
@@ -1,0 +1,14 @@
+La création des BG suivants n'a pas pu être effectués car il existait déjà un BG avec le nom.<br>
+Il se peut qu'un changement au niveau des sources de données fasse que le BG avec le nom "existant" soit en fait un BG qui est passé en "ghost" car devant être supprimé. Et donc, vu qu'il garde
+son nom "normal" pendant qu'il est en mode "ghost", il n'est pas possible de créer l'autre BG pour qu'il prenne son nouveau nom.<br>
+Pour la résolution, il faut faire les étapes suivantes:
+<ol>
+    <li>Se connecter à vRA pour vérifier que le BG qui porte le nom posant problème soit effectivement passé en "ghost"</li>
+    <li>Si le BG est effectivement passé en "ghost", utiliser le script <i>clean-ghost-bg.ps1</i> en lui passant en paramètre le nom du BG à supprimer (voir le USAGE du script pour les paramètres)</li>
+</ol>
+
+Liste des renommages concernés:
+<br>
+<ul>
+    <li>{{bgCreateList}}</li>
+</ul>

--- a/powershell/resources/mail-templates/bg-create-duplicate.html
+++ b/powershell/resources/mail-templates/bg-create-duplicate.html
@@ -3,6 +3,7 @@ Il se peut qu'un changement au niveau des sources de données fasse que le BG av
 son nom "normal" pendant qu'il est en mode "ghost", il n'est pas possible de créer l'autre BG pour qu'il prenne son nouveau nom.<br>
 Pour la résolution, il faut faire les étapes suivantes:
 <ol>
+    <li>Attendre une journée pour voir si ce mail d'erreur est à nouveau envoyé. Il se peut en effet qu'il y ait eu marchage sur le sachet dans la gestion des unités ou des ITServices à créer et que ça va être corrigé par quelque'un.</li>
     <li>Se connecter à vRA pour vérifier que le BG qui porte le nom posant problème soit effectivement passé en "ghost"</li>
     <li>Si le BG est effectivement passé en "ghost", utiliser le script <i>clean-ghost-bg.ps1</i> en lui passant en paramètre le nom du BG à supprimer (voir le USAGE du script pour les paramètres)</li>
 </ol>

--- a/powershell/resources/mail-templates/bg-rename-duplicate.html
+++ b/powershell/resources/mail-templates/bg-rename-duplicate.html
@@ -1,4 +1,4 @@
-Les renommage de BG suivants n'ont pas pu être effectués car il existait déjà un BG avec le nouveau nom.<br>
+Les renommage des BG suivants n'ont pas pu être effectués car il existait déjà un BG avec le nouveau nom.<br>
 Il se peut qu'un changement au niveau des sources de données fasse que le BG avec le nom "cible" soit en fait un BG qui est passé en "ghost" car devant être supprimé. Et donc, vu qu'il garde
 son nom "normal" pendant qu'il est en mode "ghost", il n'est pas possible de renommer l'autre BG pour qu'il prenne son nouveau nom.<br>
 Pour la résolution, il faut faire les étapes suivantes:

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -350,12 +350,28 @@ function createOrUpdateBG
 		$customProperties["$global:VRA_CUSTOM_PROP_VRA_TENANT_NAME"] = $tenantName
 		$customProperties["$global:VRA_CUSTOM_PROP_VRA_BG_NAME"] = $bgName
 		
+		# Vu qu'on a cherché le BG par son ID et qu'on n'a pas trouvé, on regarde quand même si un BG portant le nom de celui qu'on doit
+		# créer n'existe pas déjà (si si, ça se peut #facepalm)
+		$existingBg = $vra.getBG($bgName)
+		if($null -ne $existingBg)
+		{
+			$existingBgId = (getBGCustomPropValue -bg $existingBg -customPropName $global:VRA_CUSTOM_PROP_EPFL_BG_ID)
+			$logHistory.addWarningAndDisplay(("-> Impossible to create new BG with name '{0}' (ID={1}) because another one already exists with this name (ID={2})" -f `
+												$bgName, $bgId, $existingBgId))
 
-		$logHistory.addLineAndDisplay("-> BG doesn't exists, creating...")
-		# Création du BG
-		$bg = $vra.addBG($bgName, $bgDesc, $capacityAlertsEmail, $machinePrefixId, $customProperties)
+			$notifications.bgNameAlreadyTaken += ("Existing BG {0} ,ID={1}. New BG ID={1}" -f $bgName, $existingBgId, $bgId)
 
-		$counters.inc('BGCreated')
+			$counters.inc('BGNotCreated')
+		}
+		else # Le Nom est libre, on peut aller de l'avant
+		{
+			$logHistory.addLineAndDisplay(("-> BG '{0}' (ID={1}) doesn't exists, creating..." -f $bgName, $bgId))
+			# Création du BG
+			$bg = $vra.addBG($bgName, $bgDesc, $capacityAlertsEmail, $machinePrefixId, $customProperties)
+
+			$counters.inc('BGCreated')
+		}
+		
 	}
 	# Si le BG existe,
 	else
@@ -1112,8 +1128,17 @@ function handleNotifications
 				'bgNameDuplicate'
 				{
 					$valToReplace.bgRenameList = ($uniqueNotifications -join "</li>`n<li>")
-					$mailSubject = "Error - BG cannot be renamed because of duplicate"
+					$mailSubject = "Error - BG cannot be renamed because of duplicate name"
 					$templateName = "bg-rename-duplicate"
+				}
+
+				# ---------------------------------------
+				# Pas possible de créer un BG car le nom existe déjà
+				'bgNameAlreadyTaken'
+				{
+					$valToReplace.bgCreateList = ($uniqueNotifications -join "</li>`n<li>")
+					$mailSubject = "Error - BG cannot be created because of duplicate name"
+					$templateName = "bg-create-duplicate"
 				}
 
 				default
@@ -1379,6 +1404,7 @@ try
 	$counters = [Counters]::new()
 	$counters.add('ADGroups', '# AD group processed')
 	$counters.add('BGCreated', '# Business Group created')
+	$counters.add('BGNotCreated', '# Business Group NOT created')
 	$counters.add('BGUpdated', '# Business Group updated')
 	$counters.inc('BGExisting', '# Business Group already existing')
 	$counters.add('BGNotCreated', '# Business Group not created (because of an error)')


### PR DESCRIPTION
Encore un cas de figure à gérer, très probablement suite au changement de structure organisationnel... On avait déjà traité les nom de BG dupliqué ( #205 ) lorsque l'on avait le cas de figure suivant:
1. Unité A disparaît
2. Unité B renommée en Unité A

Là, on gère le cas de figure:
1. Unité A existe
2. Unité B apparaît, avec le nom de Unité A