### PR TITLE
Billing fixes

### DIFF
--- a/powershell/billing-migrate.ps1
+++ b/powershell/billing-migrate.ps1
@@ -45,9 +45,9 @@ function execRequest([string]$request)
 
     $res = $sqldb.execute($request)
 
-    if($res -eq 1)
+    if($res -gt 0)
     {
-        Write-Host -ForegroundColor:DarkGreen "Updated"
+        Write-Host -ForegroundColor:DarkGreen ("{0} Updated" -f $res)
     }
     else
     {
@@ -89,6 +89,10 @@ While($true)
                          $duplicates[1].entityElement, $duplicates[1].entityFinanceCenter, $duplicates[0].entityId
                     execRequest -request $request
     
+                    # On attache les éventuelles mesures faites à la nouvelle entrée pour qu'elles soient à l'ancienne
+                    $request = "UPDATE dbo.BillingItem SET parentEntityId='{0}' WHERE parentEntityId='{1}'" -f $duplicates[0].entityId, $duplicates[1].entityId
+                    execRequest -request $request
+
                     $request = "DELETE FROM dbo.BillingEntity WHERE entityId='{0}'" -f $duplicates[1].entityId
                     execRequest -request $request
                 

--- a/powershell/billing-migrate.ps1
+++ b/powershell/billing-migrate.ps1
@@ -1,0 +1,141 @@
+
+param([string]$targetEnv)
+
+# Inclusion des fichiers nécessaires (génériques)
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "define.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "LogHistory.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "ConfigReader.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "NotificationMail.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "Counters.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "SQLDB.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "SecondDayActions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "APIUtils.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPI.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPICurl.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "CopernicAPI.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "vRAAPI.inc.ps1"))
+
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "billing", "Billing.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "billing", "BillingS3Bucket.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "billing", "BillingNASVolume.inc.ps1"))
+
+# Fichiers propres au script courant 
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "XaaS", "functions.inc.ps1"))
+
+# Chargement des fichiers de configuration
+$configGlobal = [ConfigReader]::New("config-global.json")
+$configBilling = [ConfigReader]::New("config-billing.json")
+$configVra = [ConfigReader]::New("config-vra.json")
+
+
+    # Pour accéder à la base de données
+$sqldb = [SQLDB]::new([DBType]::MSSQL,
+                    $configVra.getConfigValue(@($targetEnv, "db", "host")),
+                    $configVra.getConfigValue(@($targetEnv, "db", "dbName")),
+                    $configVra.getConfigValue(@($targetEnv, "db", "user")),
+                    $configVra.getConfigValue(@($targetEnv, "db", "password")),
+                    $configVra.getConfigValue(@($targetEnv, "db", "port")))
+
+
+
+function execRequest([string]$request)
+{
+    Write-Host "$($request) " -NoNewline
+
+    $res = $sqldb.execute($request)
+
+    if($res -eq 1)
+    {
+        Write-Host -ForegroundColor:DarkGreen "Updated"
+    }
+    else
+    {
+        Write-Host -ForegroundColor:DarkYellow "No Update"
+    }
+}
+
+
+$partList = @(
+    "1 - Clean data",
+    "2 - 'entityType' to 'entityCustomId'",
+    "3 - update 'entityElement' value",
+    "0 - Exit"
+)
+
+While($true)
+{
+    Write-Host ("Parts:`n{0}" -f ($partList -join "`n") )
+
+    $part = Read-Host "Select Part"
+    
+    switch($part)
+    {
+    
+        1 {
+            $entityList =  $sqldb.execute("SELECT * FROM dbo.BillingEntity")
+    
+            ForEach($entity in $entityList)
+            {
+                $id, $name = $entity.entityElement.split(" ")
+                $name = $name -join " "
+    
+                $duplicates = $sqldb.execute("SELECT * FROM dbo.BillingEntity WHERE entityElement LIKE '$($id) %' ORDER BY entityId ASC")
+    
+                # Si doublons
+                if($duplicates.count -eq 2)
+                {
+                    $request = "UPDATE dbo.BillingEntity SET entityElement = '{0}', entityFinanceCenter = '{1}' WHERE entityId='{2}'" -f `
+                         $duplicates[1].entityElement, $duplicates[1].entityFinanceCenter, $duplicates[0].entityId
+                    execRequest -request $request
+    
+                    $request = "DELETE FROM dbo.BillingEntity WHERE entityId='{0}'" -f $duplicates[1].entityId
+                    execRequest -request $request
+                
+                }
+            }
+        }
+    
+        2 {
+            $dummy = Read-Host "Please add 'entityCustomId' (VARCHAR(50), NULL) column and hit ENTER: "
+            $entityList = $sqldb.execute("SELECT * FROM dbo.BillingEntity")
+    
+            ForEach($entity in $entityList)
+            {
+                $id, $name = $entity.entityElement.split(" ")
+                $name = $name -join " "
+                $request = "UPDATE dbo.BillingEntity SET entityCustomId='$($id)' WHERE entityId='$($entity.entityId)'"
+    
+                execRequest -request $request
+            }
+    
+            $dummy = Read-Host "Edit/add UNIQUE index (BillingEntityUniq) to use 'entityCustomId' column and hit Enter"
+            
+        }
+    
+        3 {
+            $entityList = $sqldb.execute("SELECT * FROM dbo.BillingEntity")
+    
+            ForEach($entity in $entityList)
+            {
+                $id, $name = $entity.entityElement.split(" ")
+                $name = $name -join " "
+    
+                $request = "UPDATE dbo.BillingEntity SET entityElement='$($name)' WHERE entityId='$($entity.entityId)'"
+    
+                execRequest -request $request
+            }
+    
+            $dummy = Read-Host "Rename column 'entityElement' to 'entityName' and hit Enter"
+    
+        }
+    
+        0 {
+            exit
+        }
+    
+        default {
+            Write-Host -ForegroundColor:DarkRed "Incorrect part!"
+        }
+    }
+}

--- a/powershell/resources/mail-templates/billing-error-bill-per-email.html
+++ b/powershell/resources/mail-templates/billing-error-bill-per-email.html
@@ -1,0 +1,5 @@
+Les factures pour les entités suivantes n'ont pas pu être envoyées par email pour la facturation du service <b>{{serviceName}}</b> et l'environnement <b>{{targetEnv}}</b> pour les raisons
+décrite ci-dessous.<br>
+<ul>
+    <li>{{entityList}}</li>
+</ul>

--- a/powershell/xaas-billing.ps1
+++ b/powershell/xaas-billing.ps1
@@ -381,7 +381,7 @@ try
             # Parcours des entités
             ForEach($entity in $entityList)
             {
-                $logHistory.addLineAndDisplay(("Processing entity {0} ({1})..." -f $entity.entityElement, $entity.entityType))
+                $logHistory.addLineAndDisplay(("Processing entity {0} ({1})..." -f $entity.entityName, $entity.entityType))
 
                 $counters.inc('entityProcessed')
 
@@ -517,7 +517,7 @@ try
                     # Si on n'a pas atteint le montant minimum pour émettre une facture pour l'entité courante,
                     if($totalPrice -lt $global:BILLING_MIN_MOUNT_CHF)
                     {
-                        $logHistory.addLineAndDisplay(("Entity '{0}' won't be billed this month, bill amount to small ({1} CHF)" -f $entity.entityElement, $totalPrice))
+                        $logHistory.addLineAndDisplay(("Entity '{0}' won't be billed this month, bill amount to small ({1} CHF)" -f $entity.entityName, $totalPrice))
                         $counters.inc('billSkippedToLow')
                     }
                     else # On a atteint le montant minimum pour facturer 
@@ -536,7 +536,7 @@ try
 
                             # Entête
                             billingForType = $entity.entityType
-                            billingForElement = $entity.entityElement
+                            billingForElement = ("{0} {1}" -f $entity.entityCustomId, $entity.entityName)
                             billReference = $billReference
                             financeCenter = $entity.entityFinanceCenter
                             reportDate = $curDateGoodLooking 
@@ -583,7 +583,7 @@ try
                         $billingTemplateHtml= replaceInString -str $billingTemplate -valToReplace $billingDocumentReplace 
 
                         # Génération du nom du fichier PDF de sortie
-                        $PDFFilename = "{0}__{1}.pdf" -f ($billReference, $entity.entityElement)
+                        $PDFFilename = "{0}__{1} {2}.pdf" -f ($billReference, $entity.entityCustomId, $entity.entityName)
                         $targetPDFPath = ([IO.Path]::Combine($global:XAAS_BILLING_PDF_FOLDER, $PDFFilename))
 
                         $logHistory.addLineAndDisplay(("> Generating PDF '{0}'" -f $targetPDFPath))
@@ -632,14 +632,15 @@ try
                                 {
                                     # Enregistrement de l'erreur
                                     $errorId = "{0}_{1}" -f (Get-Date -Format "yyyyMMdd_hhmmss"), $entity.entityId
-                                    $errorMsg = "Error adding Copernic Bill for entity '{0}'`nError message was: {1}" -f $entity.entityElement, $result.error
+                                    $errorMsg = "Error adding Copernic Bill for entity '{0}' ({1})`nError message was: {2}" -f $entity.entityName, $entity.entityCustomId, $result.error
                                     $errorFolder = saveRESTError -category "billing" -errorId $errorId -errorMsg $errorMsg -jsonContent $copernic.getLastBodyJSON()
                                     $logHistory.addLineAndDisplay(("> Error sending bill to Copernic for entity ID (error: {0}). Details can be found in folder '{1}'" -f $result.error, $errorFolder))
 
                                     $counters.inc('billCopernicError')
 
                                     # Ajout du nécessaire pour les notifications
-                                    $notifications.copernicBillNotSent += "{0} ({1}) - Error logs are on {2} in folder {3} " -f $entity.entityElement, $entity.entityType, $env:computername, $errorFolder
+                                    $notifications.copernicBillNotSent += "{0} (CustomId: {1}, Type: {2}) - Error logs are on {3} in folder {4} " -f `
+                                                                $entity.entityName, $entity.entityCustomId, $entity.entityType, $env:computername, $errorFolder
                                 }
                                 else # Pas d'erreur
                                 {
@@ -656,7 +657,8 @@ try
                                         $logHistory.addLineAndDisplay("> Bill sent to Copernic in SIMULATION MODE without any error")
                                     }
 
-                                    $logHistory.addLineAndDisplay(("> {0} items '{1}' set as billed for entity '{2}'" -f $itemList.count, ($billedItemTypes -join "', '"), $entity.entityElement))
+                                    $logHistory.addLineAndDisplay(("> {0} items '{1}' set as billed for entity '{2}' ({3})" -f `
+                                                    $itemList.count, ($billedItemTypes -join "', '"), $entity.entityName, $entity.entityCustomId))
                                     $counters.inc('billSentToCopernic')    
 
                                 } # Fin si pas d'erreur
@@ -687,8 +689,8 @@ try
                                 # On ajoute l'erreur pour que ça soit envoyé par email
                                 # Le développeur est tout à fait conscient que si on arrive ici et qu'on ne peut pas faire de facturation, le fichier PDF
                                 # aura malgré tout déjà été créé... ce n'est pas grave, y'a des choses pires dans la vie.
-                                $logHistory.addLineAndDisplay(("> Incorrect finance center ({0}) for entity '{1}'" -f $entity.entityFinanceCenter, $entity.entityElement))
-                                $notifications.incorrectFinanceCenter += ("Entity: {0} - Finance Center: {1}" -f $entity.entityElement, $entity.entityFinanceCenter)
+                                $logHistory.addLineAndDisplay(("> Incorrect finance center ({0}) for entity '{1}' ({2})" -f $entity.entityFinanceCenter, $entity.entityName, $entity.entityCustomId))
+                                $notifications.incorrectFinanceCenter += ("Entity: {0} ({1}) - Finance Center: {2}" -f $entity.entityName, $entity.entityCustomId, $entity.entityFinanceCenter)
                                 $counters.inc('billIncorrectFinanceCenter')
                             }
                             
@@ -701,7 +703,7 @@ try
                 }
                 else # Il n'y a aucun élément à facturer
                 {
-                    $logHistory.addLineAndDisplay(("Nothing left to bill for entity {0}" -f $entity.entityElement))
+                    $logHistory.addLineAndDisplay(("Nothing left to bill for entity {0} ({1})" -f $entity.entityName, $entity.entityCustomId))
                     $counters.inc('billSkippedNothing')
                 }
 


### PR DESCRIPTION
Petit effet de bord constaté suite au changement du noms des unités. Comme on avait concaténé les ID (no d'unité) et les noms d'unité au sein d'un même champ, eh bien il devenait impossible de retrouver ses petits lorsque le nom de l'unité changeait... et donc on créait une nouvelle entrée dans la DB... et c'était l'ancienne qui était prise pour une facturation incorrecte... 🤦‍♂️
Cette PR corrige donc les choses suivantes:
- Ajout d'une nouvelle colonne `entityCustomId` dans la table `BillingEntity` pour séparer les informations
- Renommage de la colonne `entityElement` en `entityName`
- Reformatage des données pour remplir `entityCustomId` et mettre la bonne valeur dans `entityName`
- Suppression entrées ajoutées à double + "link" des potentiels "BillingItem" qui seraient liés à la nouvelle "BillingEntity" qui a été ajoutée
- Ajout d'un check pour savoir si une facture devant être envoyée par email était bien envoyée. Les admins IaaS sont notifiés en cas de problème.


# Mise en production

- [ ] Installer https://docs.microsoft.com/en-us/sql/ssms/download-sql-server-management-studio-ssms?view=sql-server-ver15 sur passerelle PowerShell de production
- [ ] Exécuter le script `billing-migrate.ps1`