### PR TITLE
Get rid of 2nd day actions duplicate names

### DIFF
--- a/powershell/resources/2nd-day-actions/myvm.json
+++ b/powershell/resources/2nd-day-actions/myvm.json
@@ -1,6 +1,6 @@
 [
     {
-        "appliesTo": "", 
+        "appliesTo": "Virtual Machine", 
         "_comment": "Custom EPFL action",
         "actions": [
             {
@@ -34,67 +34,7 @@
             {
                 "name": "[Backup] Restore",
                 "approvals": []
-            }
-        ]
-    },
-    {
-        "appliesTo": "csp.places.iaas",
-        "_comment": "Actions on VM",
-        "actions": [
-            {
-                "name": "Connect to Remote Console",
-                "approvals": []
             },
-            {
-                "name": "Connect using VMRC",
-                "approvals": []
-            }
-        ]
-    },
-    {
-        "appliesTo": "composition.resource",
-        "_comment": "Actions done on deployments",
-        "actions": [
-            {
-                "name": "Expire",
-                "approvals": []
-            },
-            {
-                "name": "Change Lease",
-                "approvals": [
-                    {
-                        "tenant": "EPFL",
-                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
-                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
-                        "JSONReplacements": {},
-                        "approvalLevels": 2
-                    },
-                    {
-                        "tenant": "ITServices",
-                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
-                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
-                        "JSONReplacements": {},
-                        "approvalLevels": 1
-                    },
-                    {
-                        "tenant": "Research",
-                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
-                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
-                        "JSONReplacements": {},
-                        "approvalLevels": 2
-                    }
-                ]
-            },
-            {
-                "name": "Change Owner",
-                "approvals": []
-            }
-        ]
-    },
-    {
-        "appliesTo": "Infrastructure.Virtual",
-        "_comment": "Actions for snapshots and VM",
-        "actions": [
             {
                 "name": "Create Snapshot",
                 "approvals": []
@@ -109,12 +49,19 @@
                 "approvals": []
             }
         ]
-    }
-    ,
+    },
     {
-        "appliesTo": "Infrastructure.Machine",
+        "appliesTo": "Machine",
         "_comment": "Actions on VM",
         "actions": [
+            {
+                "name": "Connect to Remote Console",
+                "approvals": []
+            },
+            {
+                "name": "Connect using VMRC",
+                "approvals": []
+            },
             {
                 "name": "Install Tools",
                 "approvals": []
@@ -171,6 +118,46 @@
             },
             {
                 "name": "Execute Reconfigure",
+                "approvals": []
+            }
+        ]
+    },
+    {
+        "appliesTo": "Deployment",
+        "_comment": "Actions done on deployments",
+        "actions": [
+            {
+                "name": "Expire",
+                "approvals": []
+            },
+            {
+                "name": "Change Lease",
+                "approvals": [
+                    {
+                        "tenant": "EPFL",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 2
+                    },
+                    {
+                        "tenant": "ITServices",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 1
+                    },
+                    {
+                        "tenant": "Research",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 2
+                    }
+                ]
+            },
+            {
+                "name": "Change Owner",
                 "approvals": []
             }
         ]

--- a/powershell/resources/2nd-day-actions/xaas-s3.json
+++ b/powershell/resources/2nd-day-actions/xaas-s3.json
@@ -1,7 +1,7 @@
 [
     {
-        "appliesTo": "",
-        "_comment": "S3_Bucket",
+        "appliesTo": "S3_Bucket",
+        "_comment": "Actions sur les buckets S3",
         "actions": [
             {
                 "name": "Request support (s3)",


### PR DESCRIPTION
Changement de la manière de rechercher les "day2 actions", ce qui permet d'avoir maintenant des noms identiques pour 2 actions qui s'appliquent sur 2 types d'éléments différents (noms à double qui sont gérés par vRA).

