### PR TITLE
Release 38 (CHG0040426)

### DIFF
--- a/powershell/resources/2nd-day-actions/myvm.json
+++ b/powershell/resources/2nd-day-actions/myvm.json
@@ -1,6 +1,6 @@
 [
     {
-        "appliesTo": "", 
+        "appliesTo": "Virtual Machine", 
         "_comment": "Custom EPFL action",
         "actions": [
             {
@@ -34,67 +34,7 @@
             {
                 "name": "[Backup] Restore",
                 "approvals": []
-            }
-        ]
-    },
-    {
-        "appliesTo": "csp.places.iaas",
-        "_comment": "Actions on VM",
-        "actions": [
-            {
-                "name": "Connect to Remote Console",
-                "approvals": []
             },
-            {
-                "name": "Connect using VMRC",
-                "approvals": []
-            }
-        ]
-    },
-    {
-        "appliesTo": "composition.resource",
-        "_comment": "Actions done on deployments",
-        "actions": [
-            {
-                "name": "Expire",
-                "approvals": []
-            },
-            {
-                "name": "Change Lease",
-                "approvals": [
-                    {
-                        "tenant": "EPFL",
-                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
-                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
-                        "JSONReplacements": {},
-                        "approvalLevels": 2
-                    },
-                    {
-                        "tenant": "ITServices",
-                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
-                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
-                        "JSONReplacements": {},
-                        "approvalLevels": 1
-                    },
-                    {
-                        "tenant": "Research",
-                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
-                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
-                        "JSONReplacements": {},
-                        "approvalLevels": 2
-                    }
-                ]
-            },
-            {
-                "name": "Change Owner",
-                "approvals": []
-            }
-        ]
-    },
-    {
-        "appliesTo": "Infrastructure.Virtual",
-        "_comment": "Actions for snapshots and VM",
-        "actions": [
             {
                 "name": "Create Snapshot",
                 "approvals": []
@@ -109,12 +49,19 @@
                 "approvals": []
             }
         ]
-    }
-    ,
+    },
     {
-        "appliesTo": "Infrastructure.Machine",
+        "appliesTo": "Machine",
         "_comment": "Actions on VM",
         "actions": [
+            {
+                "name": "Connect to Remote Console",
+                "approvals": []
+            },
+            {
+                "name": "Connect using VMRC",
+                "approvals": []
+            },
             {
                 "name": "Install Tools",
                 "approvals": []
@@ -171,6 +118,46 @@
             },
             {
                 "name": "Execute Reconfigure",
+                "approvals": []
+            }
+        ]
+    },
+    {
+        "appliesTo": "Deployment",
+        "_comment": "Actions done on deployments",
+        "actions": [
+            {
+                "name": "Expire",
+                "approvals": []
+            },
+            {
+                "name": "Change Lease",
+                "approvals": [
+                    {
+                        "tenant": "EPFL",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 2
+                    },
+                    {
+                        "tenant": "ITServices",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 1
+                    },
+                    {
+                        "tenant": "Research",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 2
+                    }
+                ]
+            },
+            {
+                "name": "Change Owner",
                 "approvals": []
             }
         ]

--- a/powershell/resources/2nd-day-actions/xaas-nas.json
+++ b/powershell/resources/2nd-day-actions/xaas-nas.json
@@ -1,0 +1,76 @@
+[
+    {
+        "appliesTo": "NAS_Volume",
+        "_comment": "Actions sur les volumes NAS",
+        "actions": [
+            {
+                "name": "Request support (NAS)",
+                "approvals": []
+            },
+            {
+                "name": "Delete Volume",
+                "approvals": []
+            },
+            {
+                "name": "Modify Export Policies",
+                "approvals": [] 
+            },
+            {
+                "name": "Modify Notification Mail",
+                "approvals": [] 
+            },
+            {
+                "name": "Resize Volume",
+                "approvals": [
+                    {
+                        "tenant": "EPFL",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 2
+                    },
+                    {
+                        "tenant": "ITServices",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 1
+                    },
+                    {
+                        "tenant": "Research",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 2
+                    }
+                ]
+            },
+            {
+                "name": "Modify Snapshot Policy",
+                "approvals": [
+                    {
+                        "tenant": "EPFL",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 2
+                    },
+                    {
+                        "tenant": "ITServices",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 1
+                    },
+                    {
+                        "tenant": "Research",
+                        "approvalPolicyJSON": "vra-pre-approval-policy-2nd-day-generic.json",
+                        "approvalLevelJSON": "vra-approval-level-usrgrp-admin-passthrough.json",
+                        "JSONReplacements": {},
+                        "approvalLevels": 2
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/powershell/resources/2nd-day-actions/xaas-s3.json
+++ b/powershell/resources/2nd-day-actions/xaas-s3.json
@@ -1,7 +1,7 @@
 [
     {
-        "appliesTo": "",
-        "_comment": "S3_Bucket",
+        "appliesTo": "S3_Bucket",
+        "_comment": "Actions sur les buckets S3",
         "actions": [
             {
                 "name": "Request support (s3)",

--- a/powershell/xaas-s3-endpoint.ps1
+++ b/powershell/xaas-s3-endpoint.ps1
@@ -317,6 +317,8 @@ try
             if($linkedTo -eq "")
             {
                 
+                $logHistory.addLine("Bucket is not linked to another")
+
                 # Parcours des types d'accès
                 ForEach($accessType in $global:XAAS_S3_ACCESS_TYPES)
                 {
@@ -355,9 +357,12 @@ try
             else # Le Bucket doit être link à un autre
             {
 
+                $logHistory.addLine(("Bucket has to be linked to '{0}'" -f $linkedTo))
+
                 # Parcours des types d'accès
                 ForEach($accessType in $global:XAAS_S3_ACCESS_TYPES)
                 {
+                    $logHistory.addLine(("-> Checking access type '{0}'..." -f $accessType))
                     $bucketInfos.access.$accessType = @{}
 
                     # Recherche de la policy pour le type d'accès courant
@@ -577,17 +582,26 @@ catch
     $output.error = "{0}`n`n{1}" -f $errorMessage, $errorTrace
     displayJSONOutput -output $output
 
+    $logHistory.addError(("An error occured: `nError: {0}`nTrace: {1}" -f $errorMessage, $errorTrace))
+
     # Si on était en train de créer un bucket et qu'on peut faire le cleaning
     if(($action -eq $ACTION_CREATE) -and $doCleaningIfError)
     {
         # On efface celui-ci pour ne rien garder qui "traine"
         $logHistory.addLine(("Error while creating Bucket '{0}', deleting it so everything is clean. Error was: {1}" -f $bucketInfos.bucketName, $errorMessage))
 
-        # Suppression du bucket
-        deleteBucket -scality $scality -bucketName $bucketInfos.bucketName
+        try
+        {
+            # Suppression du bucket
+            deleteBucket -scality $scality -bucketName $bucketInfos.bucketName
+        }
+        catch
+        {
+            $logHistory.addError(("Error while cleaning Bucket: `nError: {0}`nTrace: {1}" -f $_.Exception.Message, $_.ScriptStackTrace))
+        }
     }
 
-	$logHistory.addError(("An error occured: `nError: {0}`nTrace: {1}" -f $errorMessage, $errorTrace))
+	
     
     # On ajoute les retours à la ligne pour l'envoi par email, histoire que ça soit plus lisible
     $errorMessage = $errorMessage -replace "`n", "<br>"


### PR DESCRIPTION
# PR
#258 - Gestion des actions day2 avec nom dupliqué

# Autre
- Ajout des infos pour que les entitlements pour les day-2 actions pour le NAS soient créés
- Amélioration de la partie S3 afin d'avoir un peu plus de logging et aussi de gérer une éventuelle exception dans le nettoyage d'un bucket car sa création aurait levé une exception.. il s'avère que le système peut aussi lever une exception lors du nettoyage, lors d'une simplement action de "read"... donc une exception levée dans une commande passée dans un `catch`.. c'est "incexception" 🤦‍♂️