### PR TITLE
Add support groups in ISO folder's ACLs

### DIFF
--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1537,10 +1537,6 @@ try
 	$secondDayActions = [SecondDayActions]::new([EntitlementType]::User)
 	$secondDayActionsAdm = [SecondDayActions]::new([EntitlementType]::Admin)
 
-	# On détermine s'il est nécessaire de mettre à jour les ACLs des dossiers contenant les ISO
-	$forceACLsUpdateFile =  ([IO.Path]::Combine("$PSScriptRoot", $global:SCRIPT_ACTION_FILE__FORCE_ISO_FOLDER_ACL_UPDATE))
-	$forceACLsUpdate = (Test-path $forceACLsUpdateFile)
-
 	# Chargement des informations sur les unités qui doivent être facturées sur une adresse mail
 	$mandatoryEntItemsFile = ([IO.Path]::Combine($global:RESOURCES_FOLDER, "mandatory-entitled-items.json"))
 	$mandatoryEntItemsList = loadFromCommentedJSON -jsonFile $mandatoryEntItemsFile
@@ -1998,12 +1994,6 @@ try
 	if(Test-Path -Path $recreatePoliciesFile)
 	{
 		Remove-Item -Path $recreatePoliciesFile
-	}
-
-	# Si on a dû mettre à jour les ACLs des dossiers, 
-	if($forceACLsUpdate)
-	{
-		Remove-Item -Path $forceACLsUpdateFile
 	}
 
 	# Affichage des nombres d'appels aux fonctions des objets REST


### PR DESCRIPTION
# Issues
#271

- Ajout des groupes de support du BG dans les ACLs des dossiers NAS où se trouvent les ISO.
- A la création des dossier pour les ISOs, on ajoute le groupe de support.
- Si un BG existant a un groupe de support qui n'est pas géré en automatique, on contrôle si les ACLs sont correctes et on met à jour si besoin. Cette action n'est cependant faite que lors des FULL (1x par semaine)
- Déplacement du code qui contrôle si le groupe AD d'un BG a été modifié dans les X derniers jours pour qu'il s'exécute plus tôt. On évite ainsi d'exécuter du code pour rien à un moment donné.