### PR TITLE
Bugfixes 3

### DIFF
--- a/powershell/include/REST/NSXAPI.inc.ps1
+++ b/powershell/include/REST/NSXAPI.inc.ps1
@@ -691,7 +691,7 @@ class NSXAPI: RESTAPICurl
         # Création des règles
         $this.callAPI($uri, "Post", $body) | Out-Null
 
-        return $this.getFirewallSectionRules($firewallSectionId)
+        return $this.getFirewallSectionRulesList($firewallSectionId)
     }
 
     
@@ -706,7 +706,7 @@ class NSXAPI: RESTAPICurl
         # Déverrouillage de la section au cas où, histoire de pas se chopper une exception
         $this.unlockFirewallSection($firewallSectionId)
 
-        $ruleList = $this.getFirewallSectionRules($firewallSectionId)
+        $ruleList = $this.getFirewallSectionRulesList($firewallSectionId)
 
         ForEach($rule in $ruleList)
         {


### PR DESCRIPTION
- Correction d'un problème dans `NSXAPI`, introduit par le passé, lors du renommage de fonctions, tout n'avait pas été fait partout. Cela fait planter le script `sync-bg-from-ad.ps1` uniquement lorsqu'il faut créer un nouveau service dans ITServices
- Amélioration de la gestion des groupes AD pour lTServices dans `sync-ad-groups-from-various.ps1`. On virait et remettait le contenu des groupes de manière barbare pour mettre à jour mais du coup, tous les groupes étaient modifiés donc lors de l'exécution du script `sync-bg-from-ad.ps1` ils étaient tous pris comme étant modifiés dans les 2 derniers jours et c'est comme si on faisait un "full" à chaque exécution.