### PR TITLE
Release 46 (CHG0040680)

### DIFF
--- a/powershell/include/REST/APIUtils.inc.ps1
+++ b/powershell/include/REST/APIUtils.inc.ps1
@@ -180,7 +180,7 @@ class APIUtils
 
 		RET : Objet créé depuis le code JSON
 	#>
-	hidden [Object] createObjectFromJSON([string] $file, [System.Collections.IDictionary] $valToReplace)
+	[Object] createObjectFromJSON([string] $file, [System.Collections.IDictionary] $valToReplace)
 	{
 		$filePath = ""
 		# Chemin complet jusqu'au fichier à charger

--- a/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/NAS/NetAppAPI.inc.ps1
@@ -890,6 +890,33 @@ class NetAppAPI: RESTAPICurl
 
 
     <#
+		-------------------------------------------------------------------------------------
+        BUT : Modifie le commentaire d'un volume
+        
+        IN  : $vol      -> objet représentant le volume à modifier
+        IN  : $comment  -> le commentaire à mettre pour le volume
+	#>
+    [PSCustomObject] updateVolumeComment([PSCustomObject]$vol, [string]$comment)
+    {
+        # Recherche du serveur NetApp cible
+        $targetServer = $this.getServerForObject([NetAppObjectType]::Volume, $vol.uuid)
+
+        $uri = "https://{0}/api/storage/volumes/{1}" -f $targetServer, $vol.uuid
+
+        $body = @{
+            comment = $comment
+        }
+        
+        $result = $this.callAPI($uri, "PATCH", $body)
+
+        # L'opération se fait en asynchrone donc on attend qu'elle se termine
+        $this.waitForJobToFinish($targetServer, $result.job.uuid)
+
+        return $this.getVolumeById($vol.uuid)
+    }
+
+
+    <#
         =====================================================================================
                                         CIFS SHARES
         =====================================================================================

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -2298,7 +2298,8 @@ class vRAAPI: RESTAPICurl
 
 	<#
 		-------------------------------------------------------------------------------------
-		BUT : Exécute une action sur une ressource donnée.
+		BUT : Exécute une action sur une ressource donnée. On ne retourne rien car l'appel à l'API
+				ne renvoie rien non plus.
 
 		IN  : $resource 	-> Objet représentant la ressource sur laquelle effectuer l'action
 		IN  : $form			-> Objet représentant le formulaire à soumettre pour l'action

--- a/powershell/resources/json-templates/vRAAPI/vra-object-custom-prop.json
+++ b/powershell/resources/json-templates/vRAAPI/vra-object-custom-prop.json
@@ -1,0 +1,13 @@
+{
+    "componentTypeId":  "com.vmware.csp.component.iaas.proxy.provider",
+    "componentId":  null,
+    "classId":  "Infrastructure.CustomProperty",
+    "typeFilter":  null,
+    "data":  {
+                 "id":  "{{name}}",
+                 "is_encrypted":  false,
+                 "is_hidden":  false,
+                 "prompt_user":  false,
+                 "value":  "{{value}}"
+             }
+}

--- a/powershell/tools-send-its-windows-vm-list.ps1
+++ b/powershell/tools-send-its-windows-vm-list.ps1
@@ -146,7 +146,10 @@ try
             $vSphereVM = Get-VM $vm.name
             $vmView = $vSphereVM| Get-View
        
-            if($vmView.Guest.GuestFamily -like "*Windows*")
+            # On regarde dans les 2 données membres. La première est visiblement renseignée via les VMware Tools (donc fiable)
+            # Et la 2e, c'est le type de machine au niveau vSphere. Moins "fiable" mais si la première n'est pas présente, on
+            # prend celle-ci pour tenter de définir le type d'OS
+            if(($vmView.Guest.GuestFamily -like "*Windows*") -or ($vSphereVM.GuestId -like "*Windows*"))
             {
                 $logHistory.addLineAndDisplay("---> Windows VM")
 
@@ -166,10 +169,20 @@ try
                     $deploymentTag = getvRAObjectCustomPropValue -object $vm -customPropName $global:VRA_CUSTOM_PROP_EPFL_DEPLOYMENT_TAG
                 }
 
+                # On aura l'info du nom complet de l'OS uniquement si les tools sont installées
+                if($null -ne $vmView.Guest.GuestFullName)
+                {
+                    $osFullName = $vmView.Guest.GuestFullName
+                }
+                else
+                {
+                    $osFullName = "Windows Version ??"
+                }
+
                 $values = @($vm.name,
                         $deploymentTag,
                         $vmView.Summary.Runtime.PowerState,
-                        $vmView.Guest.GuestFullName,
+                        $osFullName,
                         $bg.description,
                         $bgId,
                         $serviceManager,

--- a/powershell/tools-update-vm-custom-props.ps1
+++ b/powershell/tools-update-vm-custom-props.ps1
@@ -1,0 +1,193 @@
+<#
+USAGES:
+	tools-update-vm-custom-props.ps1 -targetEnv prod|test|dev -targetTenant itservices|epfl|research
+#>
+<#
+	BUT 		: Crée/met à jour les customs props des VMs en fonction du tenant et du BG où elles se trouvent.
+
+	DATE 		: Mars 2020
+	AUTEUR 	    : Lucien Chaboudez
+
+	PARAMETRES : 
+		$targetEnv		-> nom de l'environnement cible. Ceci est défini par les valeurs $global:TARGET_ENV__* 
+						dans le fichier "define.inc.ps1"
+		$targetTenant 	-> nom du tenant cible. Défini par les valeurs $global:VRA_TENANT__* dans le fichier
+						"define.inc.ps1"
+	
+	REMARQUE : Avant de pouvoir exécuter ce script, il faudra changer la ExecutionPolicy
+				  via Set-ExecutionPolicy. Normalement, si on met la valeur "Unrestricted",
+				  cela suffit à correctement faire tourner le script. Mais il se peut que
+				  si le script se trouve sur un share réseau, l'exécution ne passe pas et
+				  qu'il soit demandé d'utiliser "Unblock-File" pour permettre l'exécution.
+				  Ceci ne fonctionne pas ! A la place il faut à nouveau passer par la
+				  commande Set-ExecutionPolicy mais mettre la valeur "ByPass" en paramètre.
+#>
+param ( [string]$targetEnv, [string]$targetTenant)
+
+
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "define.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "SecondDayActions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "Counters.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "LogHistory.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "NameGeneratorBase.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "NameGenerator.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "ConfigReader.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "NotificationMail.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "EPFLLDAP.inc.ps1"))
+
+
+# Chargement des fichiers pour API REST
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "APIUtils.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPI.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPICurl.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "vRAAPI.inc.ps1"))
+
+
+# Chargement des fichiers de configuration
+$configVra = [ConfigReader]::New("config-vra.json")
+$configGlobal = [ConfigReader]::New("config-global.json")
+
+
+
+try
+{
+	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
+	$logPath = @('vra', ('update-vm-custom-props-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()))
+	$logHistory =[LogHistory]::new($logPath, $global:LOGS_FOLDER, 120)
+
+	# On contrôle le prototype d'appel du script
+	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))
+
+	$logHistory.addLine(("Script executed as '{0}' with following parameters: `n{1}" -f $env:USERNAME, ($PsBoundParameters | ConvertTo-Json)))
+
+
+    
+	# Création de l'objet qui permettra de générer les noms des groupes AD et "groups"
+	$nameGenerator = [NameGenerator]::new($targetEnv, $targetTenant)
+
+	# Objet pour pouvoir envoyer des mails de notification
+	$valToReplace = @{
+		targetEnv = $targetEnv
+		targetTenant = $targetTenant
+	}
+	$notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, `
+												($global:VRA_MAIL_SUBJECT_PREFIX -f $targetEnv, $targetTenant), $valToReplace)
+
+
+	# Création d'un objet pour gérer les compteurs (celui-ci sera accédé en variable globale même si c'est pas propre XD)
+	$counters = [Counters]::new()
+	$counters.add('ADGroups', '# AD group processed')
+	$counters.add('projectCreated', '# Business Group created')
+
+
+    # Création d'une connexion au serveur vRA pour accéder à ses API REST
+	$logHistory.addLineAndDisplay("Connecting to vRA...")
+	$vra = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")),
+						 $targetTenant, 
+						 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "user")),
+						 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "password")))
+
+    # Parcours de la liste des BG
+    Foreach ($bg in $vra.getBGList() )
+    {
+        $logHistory.addLineAndDisplay(("Processing BG '{0}'..." -f $bg.name))
+
+        $logHistory.addLineAndDisplay("> Getting VM List...")   
+
+        $vmList = $vra.getBGItemList($bg, $global:VRA_ITEM_TYPE_VIRTUAL_MACHINE)
+
+        $logHistory.addLineAndDisplay(("> {0} VMs found" -f $vmList.count))
+
+		# Liste des custom properties à check et des valeurs qu'elles devraient avoir
+		$customPropsToCheck = @{
+			$global:VRA_CUSTOM_PROP_VRA_BG_NAME = $bg.name
+			$global:VRA_CUSTOM_PROP_VRA_TENANT_NAME = $targetTenant
+		}
+
+		Foreach($vm in $vmList)
+        {
+            $logHistory.addLineAndDisplay((">> Processing VM '{0}'..." -f $vm.name))
+
+			$reconfigTemplate = $null
+
+			# Parcours des customs properties à contrôler
+			ForEach($customPropName in $customPropsToCheck.keys)
+			{
+				$customPropValue = getvRAObjectCustomPropValue -object $vm -customPropName $customPropName
+
+				# Si la valeur est incorrecte
+				if($customPropValue -ne $customPropsToCheck.$customPropName)
+				{
+					# Si on n'a pas encore le template
+					if($null -eq $reconfigTemplate)
+					{
+						# On récupère le nécessaire pour corriger la chose
+						$reconfigTemplate = $vra.getResourceActionTemplate($vm, "Reconfigure")
+					}
+				}
+				else # Custom prop correcte
+				{
+					# On passe à la suivante
+					continue
+				}
+
+				# Si custom prop n'existe pas
+				if($null -eq $customPropValue)
+				{
+					$logHistory.addLineAndDisplay((">>> Custom Prop '{0}' missing" -f $customPropName))
+
+					# Ajout de la custom property à la liste
+					$replace = @{
+						name = $customPropName
+						value = $customPropsToCheck.$customPropName
+					}
+					$newProp = $vra.createObjectFromJSON('vra-object-custom-prop.json', $replace)
+					$reconfigTemplate.data.customProperties += $newProp
+				}
+				else # Elle est correcte mais n'a pas la bonne valeur
+				{
+					$logHistory.addLineAndDisplay((">>> Custom Prop '{0}' incorrect ('{1}' instead of '{2}')" -f $customPropName, $customPropValue, $customPropsToCheck.$customPropName))
+					# Mise à jour
+					($reconfigTemplate.data.customProperties | Where-Object { $_.data.id -eq $customPropName }).data.value = $customPropsToCheck.$customPropName
+				}
+
+			}# FIN BOUCLE de parcours des custom property à contrôler
+
+			# Si on doit faire un reconfigure
+			if($null -ne $reconfigTemplate)
+			{
+				$logHistory.addLineAndDisplay((">> Reconfiguring VM to update custom properties..."))
+				$request = $vra.doResourceActionRequest($vm, $reconfigTemplate)
+				$request
+			}
+
+        }# FIN BOUCLE de parcours des VM du Business Group
+
+    }# FIN BOUCLE de pacours des Business Groups
+
+}
+catch # Dans le cas d'une erreur dans le script
+{
+    
+    # Récupération des infos
+    $errorMessage = $_.Exception.Message
+    $errorTrace = $_.ScriptStackTrace
+
+    $logHistory.addErrorAndDisplay(("An error occured: `nError: {0}`nTrace: {1}" -f $errorMessage, $errorTrace))
+    
+    # On ajoute les retours à la ligne pour l'envoi par email, histoire que ça soit plus lisible
+    $errorMessage = $errorMessage -replace "`n", "<br>"
+    
+    # Création des informations pour l'envoi du mail d'erreur
+    $valToReplace = @{	
+                        scriptName = $MyInvocation.MyCommand.Name
+                            computerName = $env:computername
+                            parameters = (formatParameters -parameters $PsBoundParameters )
+                            error = $errorMessage
+                            errorTrace =  [System.Net.WebUtility]::HtmlEncode($errorTrace)
+                    }
+    # Envoi d'un message d'erreur aux admins 
+    $notificationMail.send("Error in script '{{scriptName}}'", "global-error", $valToReplace)
+    
+}                         

--- a/powershell/xaas-nas-sync-volumes-names.ps1
+++ b/powershell/xaas-nas-sync-volumes-names.ps1
@@ -138,6 +138,8 @@ try
                 # Si le nom du déploiement ne correspond plus au nom du volume sur NetApp
                 if($vRAVol.name -ne $netAppVolName)
                 {
+                    $logHistory.addLineAndDisplay(("> Volume '{0}' has a new deployment name on vRA: {1}" -f $netAppVolName, $vraVol.name))
+                    
                     # Mise à jour du commentaire
                     $comment = "FriendlyName: {0}" -f $vRAVol.name
                     $netapp.updateVolumeComment($netAppVol, $comment)

--- a/powershell/xaas-nas-sync-volumes-names.ps1
+++ b/powershell/xaas-nas-sync-volumes-names.ps1
@@ -1,12 +1,10 @@
 <#
 USAGES:
-    xaas-nas-check-volume-use.ps1 -targetEnv prod|test|dev -targetTenant itservices|epfl [-sendNotifMail]
+    xaas-nas-sync-volumes-names.ps1 -targetEnv prod|test|dev -targetTenant itservices|epfl
 #>
 <#
-    BUT 		: Permettant de contrôler l'utilisation des volumes NAS et d'envoyer des mails aux
-                admins si besoin.
-                ATTENTION! Ce script ne fonctionne que pour les volumes qui sont onboardés dans vRA car
-                            il n'y a que là que l'on a les infos sur les adresses de notification!
+    BUT 		: Permettant de mettre à jour le commentaire d'un volume côté NetApp en prenant
+                    le nom du déploiement si celui-ci n'est plus égal au vrai nom du volume
                   
 
 	DATE 	: Juin 2021
@@ -22,8 +20,7 @@ USAGES:
 
 #>
 param([string]$targetEnv, 
-      [string]$targetTenant,
-      [switch]$sendNotifMail)
+      [string]$targetTenant)
 
 # Inclusion des fichiers nécessaires (génériques)
 . ([IO.Path]::Combine("$PSScriptRoot", "include", "define.inc.ps1"))
@@ -55,10 +52,6 @@ $configGlobal = [ConfigReader]::New("config-global.json")
 $configVra = [ConfigReader]::New("config-vra.json")
 $configNAS = [ConfigReader]::New("config-xaas-nas.json")
 
-# -------------------------------------------- CONSTANTES ---------------------------------------------------
-
-$PERCENT_WARNING_USAGE  = 80
-$PERCENT_CRITICAL_USAGE = 90
 
 # ----------------------------------------------------------------------------------------------------------------------
 # ----------------------------------------------------------------------------------------------------------------------
@@ -72,7 +65,7 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new(@('xaas','nas', 'check-volume-use'), $global:LOGS_FOLDER, 120)
+    $logHistory = [LogHistory]::new(@('xaas','nas', 'sync-volumes-names'), $global:LOGS_FOLDER, 120)
     
     # On commence par contrôler le prototype d'appel du script
     . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))
@@ -112,15 +105,6 @@ try
                                                     ($global:VRA_MAIL_SUBJECT_PREFIX -f $targetEnv, $targetTenant), $valToReplace)
 
 
-    # S'il a été demandé d'envoyer des mails
-    if($sendNotifMail)
-    {
-        $mailFrom = ("noreply+{0}" -f $configGlobal.getConfigValue(@("mail", "admin")))
-        # Template pour le sujet et le contenu du mail
-        $mailSubjectTemplate = "[IaaS] NAS - {{usageStatus}} - Volume {{volName}} usage is between {{percentUsageMin}}% and {{percentUsageMax}}%"
-        $mailMessageTemplate = (Get-Content -Raw -Path ( Join-Path $global:NAS_MAIL_TEMPLATE_FOLDER "volume-use.html" ) -Encoding:UTF8)
-    }
-
     $BGList = $vra.getBGList()
 
     # Parcours des BG
@@ -134,12 +118,12 @@ try
         $volList = $vra.getBGItemList($bg, $global:VRA_XAAS_NAS_DYNAMIC_TYPE)
 
         $volNo = 1
-        ForEach($vol in $volList)
+        ForEach($vRAVol in $volList)
         {
             # Recherche du "vrai" nom du volume dans les custom properties (au cas où il aurait été renommé)
-            $netAppVolName = getvRAObjectCustomPropValue -object $vol -customPropName "name"  
+            $netAppVolName = getvRAObjectCustomPropValue -object $vRAVol -customPropName "name"  
 
-            $logHistory.addLineAndDisplay(("> [{0}/{1}] Volume '{2}' (NetApp name: {3})..." -f $volNo, $volList.count, $vol.name, $netAppVolName))
+            $logHistory.addLineAndDisplay(("> [{0}/{1}] Volume '{2}' (NetApp name: {3})..." -f $volNo, $volList.count, $vRAVol.name, $netAppVolName))
 
             # Recherche des infos du volume directement sur le NAS
             $netAppVol = $netapp.getVolumeByName($netAppVolName)
@@ -151,72 +135,18 @@ try
             }
             else # Le volume existe bel et bien sur le NAS
             {
-                $usagePercent = truncateToNbDecimal -number ($netAppVol.space.used / $netAppVol.space.size * 100) -nbDecimals 1
-
-                $usageColor = $null
-
-                # Si utilisation critique
-                if($usagePercent -ge $PERCENT_CRITICAL_USAGE)
+                # Si le nom du déploiement ne correspond plus au nom du volume sur NetApp
+                if($vRAVol.name -ne $netAppVolName)
                 {
-                    $usageColor = "#e61717"
-                    $usageStatus = "CRITICAL"
-                    $percentUsageMin = $PERCENT_CRITICAL_USAGE
-                    $percentUsageMax = 100
+                    # Mise à jour du commentaire
+                    $comment = "FriendlyName: {0}" -f $vRAVol.name
+                    $netapp.updateVolumeComment($netAppVol, $comment)
                 }
-                # Utilisation Warning
-                elseif($usagePercent -ge $PERCENT_WARNING_USAGE)
-                {
-                    $usageColor = "#fca50d"
-                    $usageStatus = "WARNING"
-                    $percentUsageMin = $PERCENT_WARNING_USAGE
-                    $percentUsageMax = $PERCENT_CRITICAL_USAGE
-                }
-
-                # Si le volume a une utilisation élevée
-                if($null -ne $usageColor)
-                {
-                    $logHistory.addLineAndDisplay(("-> Usage is {0} ({1} %)" -f $usageStatus, $usagePercent))
-
-                    if($sendNotifMail)
-                    {
-                        $logHistory.addLineAndDisplay(("-> Getting notification mails..."))
-
-                        $mailList = getvRAObjectNotifMailList -vraObj $vol -mailPropName "notificationMail"
-
-                        # Définition des valeurs à remplacer dans le mail et son sujet
-                        $valToReplace = @{
-                            color = $usageColor
-                            volName = $vol.name
-                            percentUsed = $usagePercent
-                            usedGB = (truncateToNbDecimal -number ($netAppVol.space.used / 1024 / 1024 / 1024) -nbDecimals 2)
-                            totGB = (truncateToNbDecimal -number ($netAppVol.space.size / 1024 / 1024 / 1024) -nbDecimals 2)
-                            usageStatus = $usageStatus
-                            percentUsageMin = $percentUsageMin
-                            percentUsageMax = $percentUsageMax
-                        }
-
-                        # Création du sujet du mail ainsi que du message
-                        $mailSubject, $mailMessage = replaceInStrings -stringList @($mailSubjectTemplate, $mailMessageTemplate) -valToReplace $valToReplace
-
-                        ForEach($mailTo in $mailList)
-                        {
-                            $logHistory.addLineAndDisplay(("--> Sending mail to {0}" -f $mailTo))
-                            Send-MailMessage -From $mailFrom -to $mailTo -Subject $mailSubject  `
-                                -Body $mailMessage -BodyAsHtml:$true -SmtpServer "mail.epfl.ch" -Encoding:UTF8
-                        }
-
-                        # Pour ne pas faire de spam
-                        Start-Sleep -Milliseconds 500
-
-                    } # FIN S'il faut envoyer le mail
-            
-                }# FIN SI le volume a une utilisation élevée 
 
             }# FIN SI Le volume existe sur le NAS
 
             $volNo++
 
-            #break
         }# FIN BOUCLE de parcours des volumes du BG
 
     }# FIN BOUCLE de parcours des BG

--- a/powershell/xaas-nas-sync-webdav.ps1
+++ b/powershell/xaas-nas-sync-webdav.ps1
@@ -321,8 +321,11 @@ function getWebDAVShareList([vRAAPI]$vra, [NetAppAPI]$netapp)
             # On regarde si le volume doit être accédé en WebDAV
             if( (getvRAObjectCustomPropValue -object $_ -customPropName $global:VRA_XAAS_NAS_CUSTOM_PROPERTY_WEBDAV_ACCESS) -eq $true)
             {
+                # Recherche du "vrai" nom du volume dans les custom properties (au cas où il aurait été renommé)
+                $netAppVolName = getvRAObjectCustomPropValue -object $_ -customPropName "name"  
+
                 # Recherche du volume
-                $vol = $netapp.getVolumeByName($_.Name)
+                $vol = $netapp.getVolumeByName($netAppVolName.Name)
 
                 # Recherche des shares pour le volume donné et ajout à la liste
                 $netapp.getVolCIFSShareList($_) | ForEach-Object {


### PR DESCRIPTION
# PR contenues
#288 - Ajout d'un script pour mettre d'équerre 2 custom properties de VM

## XaaS NAS
- Ajout d'un script `xaas-nas-sync-volumes-names.ps1` pour mettre à jour le commentaire des volumes (côté NetApp) si le déploiement côté vRA change de nom.
- Correction d'un petit bug dans `xaas-nas-check-volumes-use.ps1` et `xaas-nas-sync-webdav.ps1` (qui n'est pas encore utilisé) afin de prendre le "vrai" nom du volume et pas celui du déploiement, car il ne correspond potentiellement plus à ce qui est sur le NetApp.

## Divers
- Script `tools-send-its-windows-vm-list.ps1` >> Ajout de la gestion des VM qui n'ont pas les tools installées

# Après merge
- Créer 2 tâches planifiées pour faire la mise à jour des commentaires des volumes en cas de renommage du déploiement
- Exécuter le script pour mettre d'équerre les custom properties des VM