### PR TITLE
Approval multi admin pass-through

### DIFF
--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -812,6 +812,9 @@ class vRAAPI: RESTAPICurl
 		IN  : $activated	-> Pour dire si l'Entitlement doit être activé ou pas.
 		IN  : $onlyForGroups	-> Tableau avec la liste des noms des groupes auquels donner accès.
 									Si vide, on ne limite à personne, open bar pour tous.
+		IN  : $onlyPrepare	-> $true|$false pour dire si on faire juste la préparation ou réellement 
+								mettre à jour. Faire juste la préparation implique de juste modifier le 
+								contenu de l'objet $ent et le retourner, sans appeler l'API pour mettre à jour.
 
 		RET : Objet contenant l'entitlement mis à jour
 	#>
@@ -820,6 +823,10 @@ class vRAAPI: RESTAPICurl
 		return $this.updateEnt($ent, $newName, $newDesc, $activated, @())
 	}
 	[PSCustomObject] updateEnt([PSCustomObject] $ent, [string] $newName, [string] $newDesc, [bool]$activated, [Array]$onlyForGroups)
+	{
+		return $this.updateEnt($ent, $newName, $newDesc, $activated, $onlyForGroups, $false)
+	}
+	[PSCustomObject] updateEnt([PSCustomObject] $ent, [string] $newName, [string] $newDesc, [bool]$activated, [Array]$onlyForGroups, [bool]$onlyPrepare)
 	{
 		$uri = "{0}/catalog-service/api/entitlements/{1}" -f $this.baseUrl, $ent.id
 
@@ -875,7 +882,11 @@ class vRAAPI: RESTAPICurl
 			}
 		}# FIN si on doit limiter à certains groupes AD
 
-
+		# SI on devait juste faire la "préparation", on retourne tel quel
+		if($onlyPrepare)
+		{
+			return $ent
+		}
 		# Mise à jour des informations
 		$this.callAPI($uri, "Put", $ent) | Out-Null
 		

--- a/powershell/resources/json-templates/vRAAPI/vra-approval-level-usrgrp-admin-passthrough.json
+++ b/powershell/resources/json-templates/vRAAPI/vra-approval-level-usrgrp-admin-passthrough.json
@@ -12,21 +12,43 @@
     "criteria": {
         "type": "not",
         "subClause": {
-            "type": "expression",
-            "operator": {
-                "type": "startsWith"
-            },
-            "leftOperand": {
-                "type": "path",
-                "path": "requestedBy~principalIdAsString"
-            },
-            "rightOperand": {
-                "type": "constant",
-                "value": {
-                    "type": "string",
-                    "value": "itadmin-"
+            "type": "and",
+            "subClauses": [
+                {
+                    "type": "expression",
+                    "operator": {
+                        "type": "startsWith"
+                    },
+                    "leftOperand": {
+                        "type": "path",
+                        "path": "requestedBy~principalIdAsString"
+                    },
+                    "rightOperand": {
+                        "type": "constant",
+                        "value": {
+                            "type": "string",
+                            "value": "itadmin-"
+                        }
+                    }
+                },
+                {
+                    "type": "expression",
+                    "operator": {
+                        "type": "equals"
+                    },
+                    "leftOperand": {
+                        "type": "path",
+                        "path": "requestedBy~principalIdAsString"
+                    },
+                    "rightOperand": {
+                        "type": "constant",
+                        "value": {
+                            "type": "string",
+                            "value": "{{tenantAPIUser}}"
+                        }
+                    }
                 }
-            }
+            ]
         }
     },
     "levelNumber": "{{preApprovalLeveNumber}}",

--- a/powershell/resources/json-templates/vRAAPI/vra-approval-level-usrgrp-admin-passthrough.json
+++ b/powershell/resources/json-templates/vRAAPI/vra-approval-level-usrgrp-admin-passthrough.json
@@ -12,7 +12,7 @@
     "criteria": {
         "type": "not",
         "subClause": {
-            "type": "and",
+            "type": "or",
             "subClauses": [
                 {
                     "type": "expression",
@@ -44,7 +44,7 @@
                         "type": "constant",
                         "value": {
                             "type": "string",
-                            "value": "{{tenantAPIUser}}"
+                            "value": "{{tenantAPIUser}}@vsphere.local"
                         }
                     }
                 }

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -616,20 +616,33 @@ function createOrUpdateBGEnt([vRAAPI]$vra, [PSCustomObject]$bg, [string]$entName
 	{
 		$ent = $ent[0]
 
-		# Si le nom a changé (car le nom du BG a changé) ou la description a changé 
+		# Si on NE DOIT PAS recréer les approval policies ET que
+		# le nom a changé (car le nom du BG a changé) ou la description a changé 
 		if(($ent.name -ne $entName) -or ($ent.description -ne $entDesc) -or `
-			((!$ent.allUsers) -and ($null -ne (Compare-Object $onlyForGroups ($ent.principals | Select-Object -ExpandProperty "value")))))
+		((!$ent.allUsers) -and ($null -ne (Compare-Object $onlyForGroups ($ent.principals | Select-Object -ExpandProperty "value")))))
 		{
-			$logHistory.addLineAndDisplay(("-> Updating Entitlement {0} for type {1}..." -f $ent.name, $entType.toString()))
-			# Mise à jour du nom/description de l'entitlement courant et on force la réactivation
-			$ent = $vra.updateEnt($ent, $entName, $entDesc, $true, $onlyForGroups)
+			# SI on doit recréer les approval policies, on ne met pas à jour l'entitlement à cet instant car ça va foirer vu
+			# qu'on essaiera d'utiliser des ID d'approval policies incorrects
+			if(Test-Path -Path ([IO.Path]::Combine("$PSScriptRoot", $global:SCRIPT_ACTION_FILE__RECREATE_APPROVAL_POLICIES)))
+			{
+				$logHistory.addWarningAndDisplay(("-> Entitlement {0} won't be updated because we are recreating approval policies..." -f $ent.name))
+			}
+			else
+			{
+				$logHistory.addLineAndDisplay(("-> Updating Entitlement {0} for type {1}..." -f $ent.name, $entType.toString()))
+				# Mise à jour du nom/description de l'entitlement courant et on force la réactivation
+				$ent = $vra.updateEnt($ent, $entName, $entDesc, $true, $onlyForGroups)
 
-			$counters.inc('EntUpdated')
+				$counters.inc('EntUpdated')
+			}
+			
 		}
 		else
 		{
 			$logHistory.addLineAndDisplay(("-> Entitlement {0} for type {1} is up-to-date" -f $ent.name, $entType.toString()))
 		}
+	
+		
 	}
 	return $ent
 }

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -621,20 +621,13 @@ function createOrUpdateBGEnt([vRAAPI]$vra, [PSCustomObject]$bg, [string]$entName
 		if(($ent.name -ne $entName) -or ($ent.description -ne $entDesc) -or `
 		((!$ent.allUsers) -and ($null -ne (Compare-Object $onlyForGroups ($ent.principals | Select-Object -ExpandProperty "value")))))
 		{
-			# SI on doit recréer les approval policies, on ne met pas à jour l'entitlement à cet instant car ça va foirer vu
-			# qu'on essaiera d'utiliser des ID d'approval policies incorrects
-			if(Test-Path -Path ([IO.Path]::Combine("$PSScriptRoot", $global:SCRIPT_ACTION_FILE__RECREATE_APPROVAL_POLICIES)))
-			{
-				$logHistory.addWarningAndDisplay(("-> Entitlement {0} won't be updated because we are recreating approval policies..." -f $ent.name))
-			}
-			else
-			{
-				$logHistory.addLineAndDisplay(("-> Updating Entitlement {0} for type {1}..." -f $ent.name, $entType.toString()))
-				# Mise à jour du nom/description de l'entitlement courant et on force la réactivation
-				$ent = $vra.updateEnt($ent, $entName, $entDesc, $true, $onlyForGroups)
+			$logHistory.addLineAndDisplay(("-> Updating Entitlement {0} for type {1}..." -f $ent.name, $entType.toString()))
+			# Mise à jour du nom/description de l'entitlement courant et on force la réactivation.
+			# NOTE: On met à jour uniquement l'objet en local, sans appeler l'API. Un appel à $vra.updateEnt(...) sera fait
+			# plus loin dans le code pour réellement le mettre à jour
+			$ent = $vra.updateEnt($ent, $entName, $entDesc, $true, $onlyForGroups, $true)
 
-				$counters.inc('EntUpdated')
-			}
+			$counters.inc('EntUpdated')
 			
 		}
 		else

--- a/powershell/tools-send-approval-reminder.ps1
+++ b/powershell/tools-send-approval-reminder.ps1
@@ -1,0 +1,138 @@
+<#
+USAGES:
+    tools-send-approval-reminder.ps1 -targetEnv prod|test|dev -targetTenant epfl|itservices|research
+#>
+<#
+    BUT 		: Récupère la liste des requêtes en attente d'approbation depuis X heures et 
+                    fait une relance par mail aux approbateurs avec le demandeur en copie
+                  
+
+	DATE 	: Avril 2021
+    AUTEUR 	: Lucien Chaboudez
+    
+
+#>
+param ( [string]$targetEnv, 
+        [string]$targetTenant)
+
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "define.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions-vsphere.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "EPFLLDAP.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "Counters.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "LogHistory.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "NameGeneratorBase.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "NameGenerator.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "SecondDayActions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "ConfigReader.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "NotificationMail.inc.ps1"))
+
+# Chargement des fichiers pour API REST
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "APIUtils.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPI.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPICurl.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "vRAAPI.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "SnowAPI.inc.ps1"))
+
+
+# Chargement des fichiers de configuration
+$configGlobal   = [ConfigReader]::New("config-global.json")
+$configVra      = [ConfigReader]::New("config-vra.json")
+
+# Le nombre de jours au bout desquels on se permet d'envoyer un mail pour rappeler qu'il faut approuver
+$NB_DAYS_REMINDER_DEADLINE = 4
+
+try
+{
+
+    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
+    $logPath = @('tools', ('send-approval-reminder-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.toLower()))
+    $logHistory = [LogHistory]::new($logPath, $global:LOGS_FOLDER, 120)
+    
+    # On commence par contrôler le prototype d'appel du script
+    . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))
+
+    $logHistory.addLine(("Script executed as '{0}' with following parameters: `n{1}" -f $env:USERNAME, ($PsBoundParameters | ConvertTo-Json)))
+    
+    # Objet pour pouvoir envoyer des mails de notification
+    $valToReplace = @{
+        targetEnv = $targetEnv
+        targetTenant = $targetTenant
+    }
+
+    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, `
+                                                ($global:VRA_MAIL_SUBJECT_PREFIX_NO_TENANT -f $targetEnv), $valToReplace)
+
+
+    $logHistory.addLineAndDisplay("Connecting to vRA...")
+    $vra = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")), 
+                        $targetTenant, 
+                        $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "user")), 
+                        $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "password")))
+
+
+    $logHistory.addLineAndDisplay("Getting waiting requests list...")
+
+    $waitingRequestList = $vra.getWaitingCatalogItemRequest()
+
+    $logHistory.addLineAndDisplay(("{0} request found" -f $waitingRequestList.count))
+
+    $aMomentInThePast = (Get-Date).addDays(-$NB_DAYS_REMINDER_DEADLINE)
+
+    # Parcours des requêtes
+    ForEach($waitingRequest in $waitingRequestList)
+    {
+        $logHistory.addLineAndDisplay(("-> Request '{0}' for Item '{1}'..." -f $waitingRequest.id, $waitingRequest.requestedItemName))
+        <# Il peut arriver (cas rare mais vu en test...) que des requêtes soient encore en attente pour un BG qui n'existe plus.
+        Elles ne sont donc pas visibles dans la console Web mais seulement via REST. Et il est impossible de les annuler ou autre donc... 
+        Du coup, elles seront renvoyées dans la liste des requêtes en attente. On va simplement regarder si le BG auquel elles sont
+        liées existe encore et si c'est le cas, on ira plus loin dans le processus. #>
+        if($null -ne ($vra.getBGById($waitingRequest.organization.subtenantRef)))
+        {
+            $lastUpdate = [DateTime]::Parse($waitingRequest.lastUpdated)
+
+            $logHistory.addLineAndDisplay(("--> Last request update was: {0}" -f $lastUpdate))
+            # Si la dernière mise à jour de la requête date de plus de $NB_DAYS_REMINDER_DEADLINE jours
+            if($lastUpdate -lt $aMomentInThePast)
+            {
+                $waitingRequest.preapprovalId
+            }
+            else
+            {
+                $logHistory.addLineAndDisplay("--> Not waited long enough, skipping!")
+            }
+
+        }
+        else # Le BG n'existe plus
+        {
+            $logHistory.addLineAndDisplay("--> Parent Business Group doesn't exists anymore, skipping!")
+        }
+
+        
+    }
+    
+}
+catch
+{
+    
+    # Récupération des infos
+    $errorMessage = $_.Exception.Message
+    $errorTrace = $_.ScriptStackTrace
+
+    $logHistory.addErrorAndDisplay(("An error occured: `nError: {0}`nTrace: {1}" -f $errorMessage, $errorTrace))
+    
+    # On ajoute les retours à la ligne pour l'envoi par email, histoire que ça soit plus lisible
+    $errorMessage = $errorMessage -replace "`n", "<br>"
+    
+    # Création des informations pour l'envoi du mail d'erreur
+    $valToReplace = @{
+                        scriptName = $MyInvocation.MyCommand.Name
+                        computerName = $env:computername
+                        parameters = (formatParameters -parameters $PsBoundParameters )
+                        error = $errorMessage
+                        errorTrace =  [System.Net.WebUtility]::HtmlEncode($errorTrace)
+                    }
+    # Envoi d'un message d'erreur aux admins 
+    $notificationMail.send("Error in script '{{scriptName}}'", "global-error", $valToReplace)
+}
+

--- a/powershell/tools-update-vm-custom-props.ps1
+++ b/powershell/tools-update-vm-custom-props.ps1
@@ -53,7 +53,7 @@ $configGlobal = [ConfigReader]::New("config-global.json")
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logPath = @('vra', ('update-vm-custom-props-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()))
+	$logPath = @('tools', ('update-vm-custom-props-{0}-{1}' -f $targetEnv.ToLower(), $targetTenant.ToLower()))
 	$logHistory =[LogHistory]::new($logPath, $global:LOGS_FOLDER, 120)
 
 	# On contrôle le prototype d'appel du script


### PR DESCRIPTION
- Ajout d'une possibilité supplémentaire pour qu'un utilisateur puisse faire des demandes sans avoir besoin d'approval. Cet utilisateur, c'est celui employé pour faire les appels à l'API
- Correction du script `tools-update-vm-custom-props.ps1` pour:
   - Ajouter des custom properties supplémentaires à corriger
   - Améliorer un peu les performances
   - Supprimer la limitation d'utiliser un compte `itadmin-*` pour faire les opérations
- Correction d'un bug lorsque l'on veut forcer la recréation des approval policies. Si un entitlement avait besoin d'être mis à jour (nom ou description), ça foirait car on essayait de le mettre à jour sur vRA avec un ID d'approval policy qui ne correspondait plus à rien.
- Changement du chemin du fichier de log pour le script `tools-update-vm-custom-props.ps1`