### PR TITLE
K8s robot improve

### DIFF
--- a/powershell/include/REST/XaaS/K8s/HarborAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/K8s/HarborAPI.inc.ps1
@@ -7,6 +7,7 @@
     
 	Documentation:
 	https://vsissp-harbor-t.epfl.ch/devcenter-api-2.0
+	https://editor.swagger.io/?url=https://raw.githubusercontent.com/goharbor/harbor/master/api/v2.0/swagger.yaml
 
 	
 	REMARQUES:
@@ -391,7 +392,7 @@ class HarborAPI: RESTAPICurl
 	#>
 	[Array] getProjectRobotList([PSObject]$project)
 	{
-		$uri = "{0}/projects/{1}/robots" -f $this.baseUrl, $project.project_id
+		$uri = "{0}/robots?q=Level=project,ProjectID={1}" -f $this.baseUrl, $project.project_id
 			
 		return $this.callAPI($uri, "GET", $null)
 	}
@@ -405,23 +406,23 @@ class HarborAPI: RESTAPICurl
 		IN  : $project			-> Objet représentant le projet
 		IN  : $robotName		-> Nom du compte robot
 		IN  : $robotDesc		-> Description du robot
-		IN  : $expireAtUTime	-> Temps unix auquel le robot va expirer
+		IN  : $durationDays		-> Nombre de jour de durée de vie
 		IN  : $robotType		-> Type de robot (push|pull)
 
 		RET : Le robot créé
 
 		https://vsissp-harbor-t.epfl.ch/#/Robot%20Account/post_projects__project_id__robots
 	#>
-	[PSObject] addTempProjectRobotAccount([PSObject]$project, [string]$robotName, [string]$robotDesc, [int]$expireAtUTime, [HarborRobotType]$robotType)
+	[PSObject] addTempProjectRobotAccount([PSObject]$project, [string]$robotName, [string]$robotDesc, [int]$durationDays, [HarborRobotType]$robotType)
 	{
 		
-		$uri = "{0}/projects/{1}/robots" -f $this.baseUrl, $project.project_id
+		$uri = "{0}/robots" -f $this.baseUrl
 
 		$replace = @{
 			name = $robotName
 			description = $robotDesc
-			projectId = $project.project_id
-			expireAt = @($expireAtUTime, $true)
+			projectName = $project.name
+			durationDays = @($durationDays, $true)
 			robotType = $robotType.toString().toLower()
 		}
 

--- a/powershell/include/REST/XaaS/K8s/HarborAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/K8s/HarborAPI.inc.ps1
@@ -406,12 +406,13 @@ class HarborAPI: RESTAPICurl
 		IN  : $robotName		-> Nom du compte robot
 		IN  : $robotDesc		-> Description du robot
 		IN  : $expireAtUTime	-> Temps unix auquel le robot va expirer
+		IN  : $robotType		-> Type de robot (push|pull)
 
 		RET : Le robot créé
 
 		https://vsissp-harbor-t.epfl.ch/#/Robot%20Account/post_projects__project_id__robots
 	#>
-	[PSObject] addTempProjectRobotAccount([PSObject]$project, [string]$robotName, [string]$robotDesc, [int]$expireAtUTime)
+	[PSObject] addTempProjectRobotAccount([PSObject]$project, [string]$robotName, [string]$robotDesc, [int]$expireAtUTime, [HarborRobotType]$robotType)
 	{
 		
 		$uri = "{0}/projects/{1}/robots" -f $this.baseUrl, $project.project_id
@@ -421,6 +422,7 @@ class HarborAPI: RESTAPICurl
 			description = $robotDesc
 			projectId = $project.project_id
 			expireAt = @($expireAtUTime, $true)
+			robotType = $robotType.toString().toLower()
 		}
 
 		$body = $this.createObjectFromJSON("xaas-k8s-add-harbor-project-robot.json", $replace)

--- a/powershell/include/XaaS/K8s/NameGeneratorK8s.inc.ps1
+++ b/powershell/include/XaaS/K8s/NameGeneratorK8s.inc.ps1
@@ -317,12 +317,30 @@ class NameGeneratorK8s: NameGeneratorBase
    #>
    [Hashtable] getHarborRobotAccountInfos([HarborRobotType]$robotType, [int]$nbDaysLifeTime)
    {
-      
+      $start = ""
+      switch($this.tenant)
+      {
+         $global:VRA_TENANT__EPFL
+         {
+            $start = $this.getDetail('unitID')
+         }
+
+         $global:VRA_TENANT__ITSERVICES
+         {
+            $start = $this.getDetail('snowServiceId')
+         }
+
+         $global:VRA_TENANT__RESEARCH
+         {
+            $start = $this.getDetail('projectId')
+         }
+      }
+
       # Et c'est avec cette expression barbare que nous ajoutons les X jours à la date courante
 		$dateInXDays = (Get-Date).AddDays($nbDaysLifeTime)
       $expireAt = [int][double]::Parse((Get-Date $dateInXDays -UFormat %s))
       
-      $robotName = "{0}{1}{2}" -f $this.getHarborProjectName(), $robotType.toString().toLower(), $expireAt
+      $robotName = "{0}-{1}-{2}" -f $start, $robotType.toString().toLower(), $expireAt
       $robotDesc = "Valid until {0}" -f $dateInXDays
       
       return @{

--- a/powershell/include/XaaS/K8s/NameGeneratorK8s.inc.ps1
+++ b/powershell/include/XaaS/K8s/NameGeneratorK8s.inc.ps1
@@ -350,6 +350,32 @@ class NameGeneratorK8s: NameGeneratorBase
    }
 
 
+   <#
+      -------------------------------------------------------------------------------------
+      BUT : Renvoie un objet avec les informations d'un robot à partir de son nom
+
+      IN  : $robotName  -> Nom du robot
+
+      RET : Objet avec les infos du robot, dans les données membres suivantes:
+            .projectName
+            .bgId
+            .type
+            .expirationTime
+   #>
+   [PSCustomObject] extractInfosFromRobotName([string]$robotName)
+   {
+      # Un nom de robot est au format "robot$<projectName>+<bgID>-<type>-<expirationTime>"
+      $dummy, $projectName, $bgId, $type, $expirationTime = [Regex]::Match($robotName, 'robot\$(.*?)\+(.*?)-(.*?)-(.*)').Groups | Select-Object -ExpandProperty value
+
+      return @{
+         projectName = $projectName
+         bgId = $bgId
+         type = $type
+         expirationTime = $expirationTime
+      }
+   }
+
+
    <# -------------------------------------------------------------------------------------
       ----------------------------------- NetWork -----------------------------------------
       ------------------------------------------------------------------------------------- #>

--- a/powershell/include/XaaS/K8s/NameGeneratorK8s.inc.ps1
+++ b/powershell/include/XaaS/K8s/NameGeneratorK8s.inc.ps1
@@ -308,20 +308,22 @@ class NameGeneratorK8s: NameGeneratorBase
       -------------------------------------------------------------------------------------
       BUT : Renvoie le nom d'un compte robot temporaire pour un projet Harbor
 
-      IN  : $nbDaysValidity	-> Nombre de jours de validité du compte
+      IN  : $robotType	      -> Type du robot
+      IN  : $nbDaysLifeTime   -> NB jours durée de vie
 
       RET : Tableau associatif avec:
             .name       -> le nom du robot
             .desc       -> la description
             .expireAt   -> Unix time de la date d'expiration
    #>
-   [Hashtable] getHarborRobotAccountInfos([string]$nbDaysValidity)
+   [Hashtable] getHarborRobotAccountInfos([HarborRobotType]$robotType, [int]$nbDaysLifeTime)
    {
+      
       # Et c'est avec cette expression barbare que nous ajoutons les X jours à la date courante
-		$dateInXDays = (Get-Date).AddDays($nbDaysValidity)
+		$dateInXDays = (Get-Date).AddDays($nbDaysLifeTime)
       $expireAt = [int][double]::Parse((Get-Date $dateInXDays -UFormat %s))
       
-      $robotName = "{0}{1}" -f $this.getHarborProjectName(), $expireAt
+      $robotName = "{0}{1}{2}" -f $this.getHarborProjectName(), $robotType.toString().toLower(), $expireAt
       $robotDesc = "Valid until {0}" -f $dateInXDays
       
       return @{

--- a/powershell/include/XaaS/K8s/NameGeneratorK8s.inc.ps1
+++ b/powershell/include/XaaS/K8s/NameGeneratorK8s.inc.ps1
@@ -314,7 +314,6 @@ class NameGeneratorK8s: NameGeneratorBase
       RET : Tableau associatif avec:
             .name       -> le nom du robot
             .desc       -> la description
-            .expireAt   -> Unix time de la date d'expiration
    #>
    [Hashtable] getHarborRobotAccountInfos([HarborRobotType]$robotType, [int]$nbDaysLifeTime)
    {
@@ -329,7 +328,6 @@ class NameGeneratorK8s: NameGeneratorBase
       return @{
          name =$robotName
          desc = $robotDesc
-         expireAt = $expireAt
       }
    }
 

--- a/powershell/include/XaaS/K8s/define.inc.ps1
+++ b/powershell/include/XaaS/K8s/define.inc.ps1
@@ -28,3 +28,10 @@ $global:CONTOUR_NAMESPACE = "projectcontour"
 $global:PSP_PRIVILEGED = $false
 $global:PSP_ALLOW_PRIVILEGE_ESCALATION = $false
 $global:RESOURCE_QUOTA_LB_AND_NODEPORTS = 0
+
+# Type de robot pour Harbor et leur durée de vie en jours
+enum HarborRobotType
+{
+   Push = 182
+   Pull = 365
+}

--- a/powershell/resources/json-templates/XaaS/K8s/xaas-k8s-add-harbor-project-robot.json
+++ b/powershell/resources/json-templates/XaaS/K8s/xaas-k8s-add-harbor-project-robot.json
@@ -1,11 +1,19 @@
 {
-    "access": [
-      {
-        "action": "{{robotType}}",
-        "resource": "/project/{{projectId}}/repository"
-      }
-    ],
-    "name": "{{name}}",
-    "expire_at": "{{expireAt}}",
-    "description": "{{description}}"
-  }
+  "name": "{{name}}",
+  "duration": "{{durationDays}}", // doit être un INT, pas un STRING
+  "description": "{{description}}",
+  "disable": false,
+  "level": "project",
+  "permissions": [
+    {
+      "namespace": "{{projectName}}",
+      "kind": "project",
+      "access": [
+        {
+          "resource": "repository",
+          "action": "{{robotType}}"
+        }
+      ]
+    }
+  ]
+}

--- a/powershell/resources/json-templates/XaaS/K8s/xaas-k8s-add-harbor-project-robot.json
+++ b/powershell/resources/json-templates/XaaS/K8s/xaas-k8s-add-harbor-project-robot.json
@@ -1,11 +1,7 @@
 {
     "access": [
       {
-        "action": "push",
-        "resource": "/project/{{projectId}}/repository"
-      },
-      {
-        "action": "pull",
+        "action": "{{robotType}}",
         "resource": "/project/{{projectId}}/repository"
       }
     ],

--- a/powershell/xaas-k8s-endpoint.ps1
+++ b/powershell/xaas-k8s-endpoint.ps1
@@ -806,7 +806,7 @@ try
                 $logHistory.addLine(("> Adding '{0}' robots in Harbor Project..." -f $_.toString()))
                 # Récupération des informations sur le robot (nom, description, temps unix de fin de validité)
                 $robotInfos = $nameGeneratorK8s.getHarborRobotAccountInfos($_, $ROBOT_NB_DAYS_INITIAL_LIFETIME)
-                $robot = $harbor.addTempProjectRobotAccount($harborProject, $robotInfos.name, $robotInfos.desc, $robotInfos.expireAt, $_)
+                $robot = $harbor.addTempProjectRobotAccount($harborProject, $robotInfos.name, $robotInfos.desc, $ROBOT_NB_DAYS_INITIAL_LIFETIME, $_)
                 $allRobots.($_.toString().toLower()) = @{
                     name = $robot.name
                     token = $robot.secret
@@ -1204,7 +1204,7 @@ try
 
             # Récupération des informations sur le robot (nom, description, temps unix de fin de validité)
             $robotInfos = $nameGeneratorK8s.getHarborRobotAccountInfos($robotType, ([HarborRobotType]$robotType).value__)
-            $robot = $harbor.addTempProjectRobotAccount($harborProject, $robotInfos.name, $robotInfos.desc, $robotInfos.expireAt, $robotType)
+            $robot = $harbor.addTempProjectRobotAccount($harborProject, $robotInfos.name, $robotInfos.desc, ([HarborRobotType]$robotType).value__, $robotType)
 
             # Résultat
             $output.results += @{

--- a/powershell/xaas-k8s-tools.ps1
+++ b/powershell/xaas-k8s-tools.ps1
@@ -1,0 +1,294 @@
+<#
+USAGES:
+    xaas-k8s-tools.ps1 -targetEnv prod|test|dev -targetTenant itservices|epfl -action robotReminder
+    xaas-k8s-tools.ps1 -targetEnv prod|test|dev -targetTenant itservices|epfl -action delOldRobots
+#>
+<#
+    BUT 		: Script contenant diverses commandes pour effectuer des actinos sur l'infrastructure K8s
+                  
+
+	DATE 	: Juin 2021
+    AUTEUR 	: Lucien Chaboudez
+    
+    VERSION : 1.00
+
+    REMARQUES : 
+    - Avant de pouvoir exécuter ce script, il faudra changer la ExecutionPolicy via Set-ExecutionPolicy. 
+        Normalement, si on met la valeur "Unrestricted", cela suffit à correctement faire tourner le script. 
+        Mais il se peut que si le script se trouve sur un share réseau, l'exécution ne passe pas et qu'il 
+        soit demandé d'utiliser "Unblock-File" pour permettre l'exécution. Ceci ne fonctionne pas ! A la 
+        place il faut à nouveau passer par la commande Set-ExecutionPolicy mais mettre la valeur "ByPass" 
+        en paramètre.
+
+#>
+param([string]$targetEnv,
+      [string]$targetTenant,
+      [string]$action)
+
+
+# Inclusion des fichiers nécessaires (génériques)
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "define.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "LogHistory.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "ConfigReader.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "NotificationMail.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "Counters.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "NameGeneratorBase.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "NameGenerator.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "SecondDayActions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "EPFLLDAP.inc.ps1"))
+
+# Fichiers propres au script courant 
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "XaaS", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "XaaS", "K8s", "define.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "XaaS", "K8s", "NameGeneratorK8s.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "XaaS", "K8s", "TKGIKubectl.inc.ps1"))
+
+# Chargement des fichiers pour API REST
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "APIUtils.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPI.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPICurl.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "vRAAPI.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "NSXAPI.inc.ps1"))
+
+# Chargement des fichiers propres au PKS VMware
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "XaaS", "K8s", "PKSAPI.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "XaaS", "K8s", "HarborAPI.inc.ps1"))
+
+# Chargement des fichiers de configuration
+$configGlobal   = [ConfigReader]::New("config-global.json")
+$configVra      = [ConfigReader]::New("config-vra.json")
+$configK8s      = [ConfigReader]::New("config-xaas-k8s.json")
+$configLdapAD   = [ConfigReader]::New("config-ldap-ad.json")
+
+# -------------------------------------------- CONSTANTES ---------------------------------------------------
+
+# Liste des actions possibles
+$ACTION_ROBOT_REMINDER                          = "robotReminder"
+$ACTION_DEL_OLD_ROBOTS                          = "delOldRobots"
+
+
+# Nombre de jours à partir desquels (avant l'expiration d'un robot) on va commencer à envoyer un mail pour ceux qui vont disparaître
+$BEFORE_EXPIRE_NB_DAYS_REMINDER                 = 7
+# Durée après laquelle on peut supprimer un robot expiré
+$OLD_ROBOTS_GRACE_PERIOD_DAYS                   = 7
+
+
+# -------------------------------------------- FONCTIONS ---------------------------------------------------
+
+
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------------------
+# ---------------------------------------------- PROGRAMME PRINCIPAL ---------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------------------
+
+try
+{
+
+    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
+    $logHistory = [LogHistory]::new(@('xaas', 'k8s', 'tools'), $global:LOGS_FOLDER, 30)
+    
+    # On met en minuscules afin de pouvoir rechercher correctement dans le fichier de configuration (vu que c'est sensible à la casse)
+    $targetEnv = $targetEnv.ToLower()
+    $targetTenant = $targetTenant.ToLower()
+
+    # Objet pour pouvoir envoyer des mails de notification
+    $valToReplace = @{
+		targetEnv = $targetEnv
+		targetTenant = $targetTenant
+	}
+    $notificationMail = [NotificationMail]::new($configGlobal.getConfigValue(@("mail", "admin")), $global:MAIL_TEMPLATE_FOLDER, `
+                        ($global:VRA_MAIL_SUBJECT_PREFIX -f $targetEnv, $targetTenant), $valToReplace)
+                        
+    # On commence par contrôler le prototype d'appel du script
+    . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))
+
+    # Ajout d'informations dans le log
+    $logHistory.addLine(("Script executed as '{0}' with following parameters: `n{1}" -f $env:USERNAME, ($PsBoundParameters | ConvertTo-Json)))
+
+    # Création de l'objet qui permettra de générer les noms des groupes AD et "groups"
+    $nameGeneratorK8s = [NameGeneratorK8s]::new($targetEnv, $targetTenant)
+
+    # Pour faire les recherches dans LDAP
+	$ldap = [EPFLLDAP]::new($configLdapAd.getConfigValue(@("user")), $configLdapAd.getConfigValue(@("password")))      
+
+    # Création d'une connexion au serveur vRA pour accéder à ses API REST
+	$vra = [vRAAPI]::new($configVra.getConfigValue(@($targetEnv, "infra", "server")),
+						 $targetTenant, 
+						 $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "user")),
+                         $configVra.getConfigValue(@($targetEnv, "infra", $targetTenant, "password")))
+
+    # Création d'une connexion au serveur Harbor pour accéder à ses API REST
+	$harbor = [HarborAPI]::new($configK8s.getConfigValue(@($targetEnv, "harbor", "server")),
+            $configK8s.getConfigValue(@($targetEnv, "harbor", "user")),
+            $configK8s.getConfigValue(@($targetEnv, "harbor", "password")),
+            $ldap)
+
+
+    # Si on doit activer le Debug,
+    if(Test-Path (Join-Path $PSScriptRoot "$($MyInvocation.MyCommand.Name).debug"))
+    {
+        # Activation du debug
+        $vra.activateDebug($logHistory)
+        $harbor.activateDebug($logHistory)        
+    }
+
+    # Création d'un objet pour gérer les compteurs (celui-ci sera accédé en variable globale même si c'est pas propre XD)
+    $counters = [Counters]::new()
+    
+
+    $now = getUnixTimestamp
+
+    # -------------------------------------------------------------------------
+    # En fonction de l'action demandée
+    switch ($action)
+    {
+        <#
+        ----------------------------------
+        ------------- CLUSTER ------------
+        #>
+
+        # --- Rappel sur les robots qui vont bientôt expirer
+        $ACTION_ROBOT_REMINDER
+        {
+            Throw "To finalize !"
+            # Pour savoir à quel BG est attaché chaque robot
+            $bgToRobots = @{}
+
+            $expireBeforeNbSec = ($BEFORE_EXPIRE_NB_DAYS_REMINDER * 24 * 60 * 60)
+
+            $logHistory.addLineAndDisplay("Getting all robots list...")
+            $robotList = $harbor.getRobotList()
+
+            # Parcours des robots qui existent
+            ForEach($robot in $robotList)
+            {
+                $logHistory.addLineAndDisplay((">> Robot '{0}'" -f $robot.name))
+                
+                $robotInfos = $nameGeneratorK8s.extractInfosFromRobotName($robot.name)
+                
+                $logHistory.addLineAndDisplay((">> Belongs to BG id '{0}'" -f $robotInfos.bgId))
+
+                # Si le robot va expirer bientôt
+                if(( $now -gt ($robotInfos.expirationTime - $expireBeforeNbSec)) -and ($now -lt $robotInfos.expirationTime))
+                {
+                    $logHistory.addLineAndDisplay((">> Robot will expire in less than {0} days" -f $BEFORE_EXPIRE_NB_DAYS_REMINDER))
+                    # SI on n'a pas encore d'infos pour le BG du robot
+                    if($bgToRobots.keys -notcontains $robotInfos.bgId)
+                    {
+                        # Ajout d'une liste vide
+                        $bgToRobots.add($robotInfos.bgId, @())
+                    }
+
+                    $bgToRobots.($robotInfos.bgId) += $robotInfos
+
+                }# FIN SI le robot expire bientôt
+
+            } # FIN BOUCLE de parcours des robots
+
+            $logHistory.addLineAndDisplay(("There is/are {0} BG with robots" -f $bgToRobots.Count))
+            # Parcours des BG pour lequels on a des robots
+            ForEach($bgId in $bgToRobots.keys)
+            {
+                $bg = $vra.getBGByCustomId($bgId)
+                $logHistory.addLineAndDisplay(("> BG ID '{0}' => '{1}'" -f $bgId, $bg.name))
+
+                $accessGroupList = @(getBGAccessGroupList -vra $vra -bg $bg -targetTenant $targetTenant)
+                $logHistory.addLineAndDisplay(("> Access groups are:`n- {0}" -f ($accessGroupList -join '`n- ')))
+
+                #TODO: Finaliser
+                #$mailList =
+            }
+
+        }# FIN CASE rappel sur les robots qui vont bientôt expirer
+
+
+        # --- Effacement des robots expirés depuis un certain temps
+        $ACTION_DEL_OLD_ROBOTS
+        {
+            $counters.add('robots', '# total Robots')
+            $counters.add('robotsDeleted', '# deleted Robots')
+            $counters.add('robotsGracePeriod', '# Robots in grace period')
+
+            $logHistory.addLineAndDisplay("Getting all robots list...")
+            $robotList = $harbor.getRobotList()
+            $logHistory.addLineAndDisplay(("{0} robot(s) found" -f $robotList.count))
+
+            $counters.set('robots', $robotList.count)
+
+            $gracePeriodNbSec = ($OLD_ROBOTS_GRACE_PERIOD_DAYS * 24 * 60 * 60)
+
+            # Parcours des robots trouvés
+            ForEach($robot in $robotList)
+            {
+                $logHistory.addLineAndDisplay(("> Robot '{0}'... " -f $robot.name))
+
+                # Si le robot est expiré
+                if($now -gt $robot.expires_at)
+                {
+                    # Si le robot a dépassé sa période de grâce
+                    if($now -gt ($robot.expires_at + $gracePeriodNbSec))
+                    {
+                        $logHistory.addLineAndDisplay(("> Robos is expired and {0} days grace period over, deleting robot..." -f $OLD_ROBOTS_GRACE_PERIOD_DAYS))
+
+                        $harbor.deleteRobot($robot)
+                        $counters.inc('robotsDeleted')
+                    }
+                    else # Le robot est dans sa période de grâce
+                    {
+                        $logHistory.addLineAndDisplay(("> Robot is expired but in grace period"))
+                        $counters.inc('robotsGracePeriod')
+                    }
+
+                }# FIN SI le robot est expiré
+
+            }# FIN BOUCLE parcours des robots
+
+        }
+
+        default
+        {
+
+        }
+    }
+
+    $logHistory.addLine("Script execution done!")
+
+    $logHistory.addLineAndDisplay($counters.getDisplay("Counters summary"))
+
+}
+catch
+{
+    # Récupération des infos
+    $errorMessage = $_.Exception.Message
+    $errorTrace = $_.ScriptStackTrace
+
+	$logHistory.addError(("An error occured: `nError: {0}`nTrace: {1}" -f $errorMessage, $errorTrace))
+    
+    # On ajoute les retours à la ligne pour l'envoi par email, histoire que ça soit plus lisible
+    $errorMessage = $errorMessage -replace "`n", "<br>"
+
+	# Création des informations pour l'envoi du mail d'erreur
+	$valToReplace = @{	
+        scriptName = $MyInvocation.MyCommand.Name
+        computerName = $env:computername
+        parameters = (formatParameters -parameters $PsBoundParameters )
+        error = $errorMessage
+        errorTrace =  [System.Net.WebUtility]::HtmlEncode($errorTrace)
+    }
+
+    # Envoi d'un message d'erreur aux admins 
+    $notificationMail.send("Error in script '{{scriptName}}'", "global-error", $valToReplace) 
+}
+finally
+{
+    if($null -ne $vra)
+    {
+        $vra.disconnect()
+    }
+}
+
+


### PR DESCRIPTION
- Utilisation de la nouvelle API pour créer les Robots
- Création distincte de robots pour le `push` et pour le `pull`
- Un robot de chaque créé avec le cluster (durée de validité: 7 jours pour chacun)
- Possibilité de créer un nouveau robot d'un type donné (`push` ou `pull`) en day-2 action, avec une durée de vie plus grande
- Nouvelle convention de nommage pour les robots, afin d'avoir l'ID du BG auquel appartient le cluster pour lequel on a à la base créé le robot.
- Nouveau script `xaas-k8s-tools.ps1` pour effacer les robots qui sont expirés depuis plus de X jours. Il permettra aussi par la suite de relancer les utilisateurs lorsque leurs robots arriveront en fin de vie. Il faut cependant attendre l'expiration des robots existants (et leur effacement) car il est nécessaire d'avoir le nouveau format de noms de robots pour que le script fonctionne (on a en effet besoin de l'ID du BG)

## Après le merge
- Récupérer la nouvelle sortie de création de cluster (ou de robot) pour mettre à jour dans confluence
- Ajouter une tâche planifiée journalière pour supprimer les robots expirés (faire un seul fichier BAT pour lancer le script `xaas-k8s-tools.ps1`)